### PR TITLE
Fix & improve activation offloading

### DIFF
--- a/policies/activation_checkpointing_functions.py
+++ b/policies/activation_checkpointing_functions.py
@@ -3,6 +3,7 @@
 
 import torch
 import os
+import collections
 import torch.distributed as dist
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper,
@@ -31,3 +32,65 @@ def apply_fsdp_checkpointing(model):
     apply_activation_checkpointing(
         model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=check_fn
     )
+
+
+class FreeEventQueue:
+    """https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_limiter_utils.py"""
+    def __init__(self):
+        self._queue = collections.deque()
+        self._max_num_inflight_copy = 2
+
+    def enqueue(self, free_event):
+        self._queue.append(free_event)
+
+    def dequeue_if_needed(self):
+        if len(self._queue) >= self._max_num_inflight_copy:
+            return self._dequeue()
+        return None
+
+    def _dequeue(self):
+        if self._queue:
+            event = self._queue.popleft()
+            return event
+        return None
+
+
+class save_on_cpu_overlap(torch.autograd.graph.saved_tensors_hooks):
+    def __init__(self):
+        copy_stream = torch.cuda.Stream()
+        current_stream = torch.cuda.current_stream()
+        pack_event_queue = FreeEventQueue()
+        unpack_event_queue = FreeEventQueue()
+
+        def _deque_event_and_synchronize(queue):
+            event = queue.dequeue_if_needed()
+            if event:
+                event.synchronize()
+
+        def _enque_event(queue):
+            free_event = torch.cuda.Event()
+            free_event.record()
+            queue.enqueue(free_event)
+
+        def pack_to_cpu(tensor):
+            _deque_event_and_synchronize(pack_event_queue)
+            copy_stream.wait_stream(current_stream)
+            with torch.cuda.stream(copy_stream):
+                packed = tensor.to("cpu", non_blocking=True)
+            tensor.record_stream(copy_stream)
+            #print(tensor.shape)
+            _enque_event(pack_event_queue)
+            return (tensor.device, packed)
+
+        def unpack_from_cpu(packed):
+            _deque_event_and_synchronize(unpack_event_queue)
+            device, tensor = packed
+            with torch.cuda.stream(copy_stream):
+                unpacked = tensor.to(device, non_blocking=True)
+            current_stream.wait_stream(copy_stream)
+            unpacked.record_stream(current_stream)
+            _enque_event(unpack_event_queue)
+            return unpacked
+
+        super().__init__(pack_to_cpu, unpack_from_cpu)
+


### PR DESCRIPTION
The `torch.distributed.algorithms._checkpoint.OffloadWrapper` seems also offloading the parameters (not only the activations) to cpu, because autograd Function also saves parameters for backward. This can be verified by the script below, see `print(tensor.shape)` in pack_hook, which also prints for Linear.weight.

cc @rohan-varma @awgu 

To implement the method, combining activation checkpointing and activation offloading, described in the [PyTorch blog](https://pytorch.org/blog/efficient-large-scale-training-with-pytorch/). We can call checkpoint_module forward (**which only saves inputs, not parameters, for backward**) under save_on_cpu_overlap. This trades off cpu memory and communication for recomputation.

The benefits of `save_on_cpu_overlap` over `save_on_cpu`:
- Copy is done in a separate stream, which overlaps with computation.
- pack_hook is non-blocking now, which (hopefully) does not block the prefetch allgather for the next layer.

Below is a script to test performance and check for correctness by setting `use_stream` to True/False. Note that if without proper synchronization, for example, omitting on record_stream, the printed sampled elements are different.

<details>
  <summary>Click me</summary>

  ```python
  import collections

import torch
import torch.nn as nn


torch.manual_seed(123)


class FreeEventQueue:
    """https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_limiter_utils.py"""
    def __init__(self):
        self._queue = collections.deque()
        self._max_num_inflight_copy = 2

    def enqueue(self, free_event):
        self._queue.append(free_event)

    def dequeue_if_needed(self):
        if len(self._queue) >= self._max_num_inflight_copy:
            return self._dequeue()
        return None

    def _dequeue(self):
        if self._queue:
            event = self._queue.popleft()
            return event
        return None


class save_on_cpu_overlap(torch.autograd.graph.saved_tensors_hooks):
    def __init__(self):
        copy_stream = torch.cuda.Stream()
        current_stream = torch.cuda.current_stream()
        pack_event_queue = FreeEventQueue()
        unpack_event_queue = FreeEventQueue()

        def _deque_event_and_synchronize(queue):
            event = queue.dequeue_if_needed()
            if event:
                event.synchronize()

        def _enque_event(queue):
            free_event = torch.cuda.Event()
            free_event.record()
            queue.enqueue(free_event)

        def pack_to_cpu(tensor):
            _deque_event_and_synchronize(pack_event_queue)
            copy_stream.wait_stream(current_stream)
            with torch.cuda.stream(copy_stream):
                packed = tensor.to("cpu", non_blocking=True)
            tensor.record_stream(copy_stream)
            #print(tensor.shape)
            _enque_event(pack_event_queue)
            return (tensor.device, packed)

        def unpack_from_cpu(packed):
            _deque_event_and_synchronize(unpack_event_queue)
            device, tensor = packed
            with torch.cuda.stream(copy_stream):
                unpacked = tensor.to(device, non_blocking=True)
            current_stream.wait_stream(copy_stream)
            unpacked.record_stream(current_stream)
            _enque_event(unpack_event_queue)
            return unpacked

        super().__init__(pack_to_cpu, unpack_from_cpu)



from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper, CheckpointImpl
from functools import partial


class Model(nn.Module):
    def __init__(
        self,
        n: int,
    ):
        super().__init__()
        self.layers = nn.ModuleList()
        self.n = n
        wrp = partial(
            checkpoint_wrapper,
            checkpoint_impl=CheckpointImpl.REENTRANT,
            preserve_rng_state=False,
        )
        for i in range(self.n):
            l = nn.Linear(dim, dim)
            l = wrp(l)
            self.layers.append(l)

    def forward(self, x):
        for i in range(self.n):
            x = self.layers[i](x)
        return x


dim = 4096
bsz = 2048 # bsz * seq_len

inputs = torch.randn(bsz, dim).cuda().requires_grad_()
out_grad = torch.ones(bsz, dim).cuda()
print("inputs ", inputs.detach()[0:5, 0])


#seq_module = nn.Sequential(*[nn.Linear(dim, dim) for _ in range(5)]).cuda()
seq_module = Model(5).cuda()

# warmup
for _ in range(5):
    out = seq_module(inputs)
    out.backward(out_grad)
torch.cuda.synchronize()

#use_stream = True
use_stream = False

for _ in range(5):
    start_event = torch.cuda.Event(enable_timing=True)
    end_event = torch.cuda.Event(enable_timing=True)
    start_event.record()
    if use_stream:
        with save_on_cpu_overlap():
            out = seq_module(inputs)
    else:
        with torch.autograd.graph.save_on_cpu(pin_memory=True):
            out = seq_module(inputs)
    out.backward(out_grad)
    end_event.record()
    torch.cuda.synchronize()
    print("elapsed time: ", start_event.elapsed_time(end_event))
    print("sampled elements: ", inputs.grad[0, :5])
  ```
</details>

On a single V100, 20% speedup is observed for this toy model. Output:

<details>
  <summary>Click me</summary>

  ```
# use_stream=True
inputs  tensor([ 0.3374, -1.2207, -0.9550,  1.7306, -0.2264], device='cuda:0')
elapsed time:  149.52761840820312
sampled elements:  tensor([-0.1949, -0.2131,  0.1653, -0.3961, -0.6375], device='cuda:0')
elapsed time:  113.87091064453125
sampled elements:  tensor([-0.2274, -0.2487,  0.1929, -0.4621, -0.7438], device='cuda:0')
elapsed time:  108.2528305053711
sampled elements:  tensor([-0.2599, -0.2842,  0.2205, -0.5281, -0.8501], device='cuda:0')
elapsed time:  107.67017364501953
sampled elements:  tensor([-0.2924, -0.3197,  0.2480, -0.5941, -0.9563], device='cuda:0')
elapsed time:  107.47408294677734
sampled elements:  tensor([-0.3248, -0.3552,  0.2756, -0.6601, -1.0626], device='cuda:0')


# use_stream=False
inputs  tensor([ 0.3374, -1.2207, -0.9550,  1.7306, -0.2264], device='cuda:0')
elapsed time:  178.19471740722656
sampled elements:  tensor([-0.1949, -0.2131,  0.1653, -0.3961, -0.6375], device='cuda:0')
elapsed time:  126.314208984375
sampled elements:  tensor([-0.2274, -0.2487,  0.1929, -0.4621, -0.7438], device='cuda:0')
elapsed time:  126.18544006347656
sampled elements:  tensor([-0.2599, -0.2842,  0.2205, -0.5281, -0.8501], device='cuda:0')
elapsed time:  126.29904174804688
sampled elements:  tensor([-0.2924, -0.3197,  0.2480, -0.5941, -0.9563], device='cuda:0')
elapsed time:  126.51510620117188
sampled elements:  tensor([-0.3248, -0.3552,  0.2756, -0.6601, -1.0626], device='cuda:0')
  ```
</details>