### PR TITLE
adding system prompt to custom dataset

### DIFF
--- a/examples/custom_dataset.py
+++ b/examples/custom_dataset.py
@@ -13,7 +13,10 @@ from llama_recipes.datasets.utils import Concatenator
 B_INST, E_INST = "[INST]", "[/INST]"
 B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"
 
-def tokenize_dialog(dialog, tokenizer):
+def tokenize_dialog(dialog, tokenizer, system_prompt=None):
+    if system_prompt and len(dialog) > 0:
+        additional_content = f"{B_SYS}{system_prompt}{E_SYS}"
+        dialog[0]['content'] = additional_content + dialog[0]['content']
     dialog_tokens = [
             tokenizer(
                 f"{B_INST} {(prompt['content']).strip()} {E_INST} {(answer['content']).strip()} ",
@@ -28,8 +31,9 @@ def tokenize_dialog(dialog, tokenizer):
     combined_tokens = {}  
     for k in dialog_tokens[0].keys():
         combined_tokens[k] = list(itertools.chain(*(t[k] for t in dialog_tokens)))
-    return combined_tokens
-
+    if system_prompt and len(dialog) > 0:
+        dialog[0]['content'] = dialog[0]['content'][len(additional_content):]
+    return combined_tokens 
 
 def get_custom_dataset(dataset_config, tokenizer, split):
     dataset = datasets.load_dataset("OpenAssistant/oasst1", split=split)


### PR DESCRIPTION
# What does this PR do?

Small update to `examples/custom_dataset.py` to add an optional system prompt argument to `tokenize_dialog()`. As shown in https://huggingface.co/blog/llama2#how-to-prompt-llama-2 for example.

## Feature/Issue validation/testing

Added an additional test `test_system_prompt()` in `tests/datasets/test_custom_dataset.py` to verify expected behavior.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?  
- [x] Did you write any new necessary tests?

Thanks for contributing 🎉!
