### PR TITLE
Fix checkpoint converter to use arguments before default behavior of checking yaml

### DIFF
--- a/src/llama_recipes/inference/checkpoint_converter_fsdp_hf.py
+++ b/src/llama_recipes/inference/checkpoint_converter_fsdp_hf.py
@@ -28,25 +28,26 @@ def main(
     HF_model_path_or_name="" # Path/ name of the HF model that include config.json and tokenizer_config.json (e.g. meta-llama/Llama-2-7b-chat-hf)
     ):
     
-    try:
-        file_name = 'train_params.yaml'
-        # Combine the directory and file name to create the full path
-        train_params_path = os.path.join(fsdp_checkpoint_path, file_name)
-        # Open the file
-        with open(train_params_path, 'r') as file:
-            # Load the YAML data
-            data = yaml.safe_load(file)
-
-            # Access the 'model_name' field
-            HF_model_path_or_name = data.get('model_name')
-
+    if not HF_model_path_or_name:
+        try:
+            file_name = 'train_params.yaml'
+            # Combine the directory and file name to create the full path
+            train_params_path = os.path.join(fsdp_checkpoint_path, file_name)
+            # Open the file
+            with open(train_params_path, 'r') as file:
+                # Load the YAML data
+                data = yaml.safe_load(file)
+    
+                # Access the 'model_name' field
+                HF_model_path_or_name = data.get('model_name')
+    
+                print(f"Model name: {HF_model_path_or_name}")
+        except FileNotFoundError:
+            print(f"The file {train_params_path} does not exist.")
+            HF_model_path_or_name = input("Please enter the model name: ")
             print(f"Model name: {HF_model_path_or_name}")
-    except FileNotFoundError:
-        print(f"The file {train_params_path} does not exist.")
-        HF_model_path_or_name = input("Please enter the model name: ")
-        print(f"Model name: {HF_model_path_or_name}")
-    except Exception as e:
-        print(f"An error occurred: {e}")
+        except Exception as e:
+            print(f"An error occurred: {e}")
         
         
     #load the HF model definition from config


### PR DESCRIPTION
Script ignores `HF_model_path_or_name` argument even if supplied and skips to getting model name from yaml file. Test if argument exists before using default approach.

Unfortunately specifying a path causes the script to break.

# What does this PR do?

This fixes the faulty default behavior of the converter script.

Fixes # (issue)
No issue

## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

No tests needed.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
