### PR TITLE
fix: assigned correct path to custom dataset example file

### DIFF
--- a/src/llama_recipes/configs/datasets.py
+++ b/src/llama_recipes/configs/datasets.py
@@ -29,6 +29,6 @@ class alpaca_dataset:
 @dataclass
 class custom_dataset:
     dataset: str = "custom_dataset"
-    file: str = "examples/custom_dataset.py"
+    file: str = "recipes/finetuning/datasets/custom_dataset.py"
     train_split: str = "train"
     test_split: str = "validation"


### PR DESCRIPTION
# What does this PR do?

- Assigns right path to example custom dataset function