### PR TITLE
Fix save metric FileNotFoundError when finetuning

### DIFF
--- a/src/llama_recipes/utils/train_utils.py
+++ b/src/llama_recipes/utils/train_utils.py
@@ -103,6 +103,8 @@ def train(model, train_dataloader,eval_dataloader, tokenizer, optimizer, lr_sche
     val_loss =[]
 
     if train_config.save_metrics:
+        if not os.path.exists(train_config.output_dir):
+            os.makedirs(train_config.output_dir, exist_ok=True)
         metrics_filename = f"{train_config.output_dir}/metrics_data_{local_rank}-{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json"
         train_step_perplexity = []
         train_step_loss = []


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug where the code attempted to save metrics during training to a file that did not exist, causing an error. The fix ensures that the code checks if the file exists before attempting to save the metrics, preventing the error from occurring.

Fixes # (issue number)

## Feature/Issue validation/testing

I tested the fix by running the training script with the provided command and verified that the metrics were saved without any errors. Here are the steps I followed:

- [x] Test saving metrics
    - Ran the training script using the following command:
    
    ```bash
    python recipes/finetuning/finetuning.py --model_name PATH//TO/Meta-Llama-3-8B --quantization \
    --use_peft --peft_method lora \
    --lora_config.r 16 \
    --lora_config.lora_dropout 0.1 \
    --num_epochs 5  \
    --batch_size_training 1 \
    --dataset alpaca_dataset \
    --batching_strategy packing \
    --output_dir ./output/peft/llama3-8B-lora-alpaca-0511-v1 \
    --use_wandb  \
    --save_metrics
    ```
    
    - Verified that metrics were saved to the specified file
    - Checked for any error messages or exceptions during the process

