### PR TITLE
Resume the fine-tuning process from the previous PEFT checkpoint folder

### DIFF
--- a/docs/multi_gpu.md
+++ b/docs/multi_gpu.md
@@ -138,8 +138,9 @@ It lets us specify the training settings for everything from `model_name` to `da
     mixed_precision: bool=True
     val_batch_size: int=1
     dataset = "samsum_dataset"
-    peft_method: str = "lora" # None,llama_adapter, prefix
+    peft_method: str = "lora" # None, llama_adapter (Caution: llama_adapter is currently not supported with FSDP)
     use_peft: bool=False
+    from_peft_checkpoint: str="" # if not empty and use_peft=True, will load the peft checkpoint and resume the fine-tuning on that checkpoint
     output_dir: str = "PATH/to/save/PEFT/model"
     freeze_layers: bool = False
     num_freeze_layers: int = 1

--- a/docs/multi_gpu.md
+++ b/docs/multi_gpu.md
@@ -34,7 +34,7 @@ The args used in the command above are:
 
 * `--use_peft` boolean flag to enable PEFT methods in the script
 
-* `--peft_method` to specify the PEFT method, here we use `lora` other options are `llama_adapter`, `prefix`.
+* `--peft_method` to specify the PEFT method, here we use `lora` other options are `llama_adapter`.
 
 We use `torchrun` here to spawn multiple processes for FSDP.
 

--- a/docs/single_gpu.md
+++ b/docs/single_gpu.md
@@ -94,8 +94,9 @@ It let us specify the training settings, everything from `model_name` to `datase
     mixed_precision: bool=True
     val_batch_size: int=1
     dataset = "samsum_dataset"
-    peft_method: str = "lora" # None,llama_adapter, prefix
+    peft_method: str = "lora" # None, llama_adapter (Caution: llama_adapter is currently not supported with FSDP)
     use_peft: bool=False
+    from_peft_checkpoint: str="" # if not empty and use_peft=True, will load the peft checkpoint and resume the fine-tuning on that checkpoint
     output_dir: str = "PATH/to/save/PEFT/model"
     freeze_layers: bool = False
     num_freeze_layers: int = 1
@@ -112,6 +113,7 @@ It let us specify the training settings, everything from `model_name` to `datase
     flop_counter_start: int = 3 # The step to start profiling, default is 3, which means after 3 steps of warmup stage, the profiler will start to count flops.
     use_profiler: bool = False # Enable pytorch profiler, can not be used with flop counter at the same time.
     profiler_dir: str = "PATH/to/save/profiler/results" # will be used if using profiler
+
 ```
 
 * [Datasets config file](../src/llama_recipes/configs/datasets.py) provides the available options for datasets.

--- a/docs/single_gpu.md
+++ b/docs/single_gpu.md
@@ -27,7 +27,7 @@ The args used in the command above are:
 
 * `--use_peft` boolean flag to enable PEFT methods in the script
 
-* `--peft_method` to specify the PEFT method, here we use `lora` other options are `llama_adapter`, `prefix`.
+* `--peft_method` to specify the PEFT method, here we use `lora` other options are `llama_adapter`.
 
 * `--quantization` boolean flag to enable int8 quantization
 

--- a/recipes/finetuning/README.md
+++ b/recipes/finetuning/README.md
@@ -48,8 +48,9 @@ It lets us specify the training settings for everything from `model_name` to `da
     mixed_precision: bool=True
     val_batch_size: int=1
     dataset = "samsum_dataset"
-    peft_method: str = "lora" # None,llama_adapter, prefix
+    peft_method: str = "lora" # None, llama_adapter (Caution: llama_adapter is currently not supported with FSDP)
     use_peft: bool=False
+    from_peft_checkpoint: str="" # if not empty and use_peft=True, will load the peft checkpoint and resume the fine-tuning on that checkpoint
     output_dir: str = "PATH/to/save/PEFT/model"
     freeze_layers: bool = False
     num_freeze_layers: int = 1
@@ -66,6 +67,7 @@ It lets us specify the training settings for everything from `model_name` to `da
     flop_counter_start: int = 3 # The step to start profiling, default is 3, which means after 3 steps of warmup stage, the profiler will start to count flops.
     use_profiler: bool = False # Enable pytorch profiler, can not be used with flop counter at the same time.
     profiler_dir: str = "PATH/to/save/profiler/results" # will be used if using profiler
+
 ```
 
 * [Datasets config file](../../src/llama_recipes/configs/datasets.py) provides the available options for datasets.

--- a/src/llama_recipes/configs/training.py
+++ b/src/llama_recipes/configs/training.py
@@ -31,6 +31,7 @@ class train_config:
     dataset = "samsum_dataset"
     peft_method: str = "lora" # None, llama_adapter (Caution: llama_adapter is currently not supported with FSDP)
     use_peft: bool=False
+    from_peft_checkpoint: str="" # if not empty and use_peft=True, will load the peft checkpoint and resume the fine-tuning on that checkpoint
     output_dir: str = "PATH/to/save/PEFT/model"
     freeze_layers: bool = False
     num_freeze_layers: int = 1

--- a/src/llama_recipes/finetuning.py
+++ b/src/llama_recipes/finetuning.py
@@ -154,12 +154,13 @@ def main(**kwargs):
         # Load the pre-trained peft model checkpoint and setup its configuration
         if train_config.from_peft_checkpoint:
             model = PeftModel.from_pretrained(model, train_config.from_peft_checkpoint, is_trainable=True)
+            peft_config = model.peft_config()
         # Generate the peft config and start fine-tuning from original model
         else:
             peft_config = generate_peft_config(train_config, kwargs)
             model = get_peft_model(model, peft_config)
-            if wandb_run:
-                wandb_run.config.update(peft_config)
+        if wandb_run:
+            wandb_run.config.update(peft_config)
         model.print_trainable_parameters()
 
 

--- a/src/llama_recipes/finetuning.py
+++ b/src/llama_recipes/finetuning.py
@@ -8,7 +8,7 @@ import fire
 import random
 import torch
 import torch.optim as optim
-from peft import get_peft_model, prepare_model_for_kbit_training
+from peft import get_peft_model, prepare_model_for_kbit_training, PeftModel
 from torch.distributed.fsdp import (
     FullyShardedDataParallel as FSDP,
     ShardingStrategy
@@ -134,7 +134,7 @@ def main(**kwargs):
     tokenizer = AutoTokenizer.from_pretrained(train_config.model_name if train_config.tokenizer_name is None else train_config.tokenizer_name)
     tokenizer.pad_token_id = tokenizer.eos_token_id
 
-    # If there is a mismatch between tokenizer vocab size and embedding matrix, 
+    # If there is a mismatch between tokenizer vocab size and embedding matrix,
     # throw a warning and then expand the embedding matrix
     if len(tokenizer) > model.get_input_embeddings().weight.shape[0]:
         print("WARNING: Resizing the embedding matrix to match the tokenizer vocab size.")
@@ -151,11 +151,16 @@ def main(**kwargs):
         model.to(torch.bfloat16)
 
     if train_config.use_peft:
-        peft_config = generate_peft_config(train_config, kwargs)
-        model = get_peft_model(model, peft_config)
+        # Load the pre-trained peft model checkpoint and setup its configuration
+        if train_config.from_peft_checkpoint:
+            model = PeftModel.from_pretrained(model, train_config.from_peft_checkpoint, is_trainable=True)
+        # Generate the peft config and start fine-tuning from original model
+        else:
+            peft_config = generate_peft_config(train_config, kwargs)
+            model = get_peft_model(model, peft_config)
+            if wandb_run:
+                wandb_run.config.update(peft_config)
         model.print_trainable_parameters()
-        if wandb_run:
-            wandb_run.config.update(peft_config)
 
 
     hsdp_device_mesh = None


### PR DESCRIPTION
# What does this PR do?
Added a new argument `from_peft_checkpoint` in the src/llama_recipes/finetuning.py to resume the fine-tuning process from the previous PEFT checkpoint folder. By default the `from_peft_checkpoint` is "". Once the `from_peft_checkpoint` string has been set, the fine-tune script will load the PEFT checkpoint to continue the fine-tune process. Must set the `--use_peft = True` and pass the checkpoint folder path to `--from_peft_checkpoint [PATH_TO_CHECKPOINT]`.  Since the peft checkpoint folder contains the `adapter_config.json `, the script will ignore the `--peft_method`and continue using the same PEFT config from `adapter_config.json`.  

Requested by [Issue 424](https://github.com/meta-llama/llama-recipes/issues/424)
## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Finetune from lora checkpoint
```
 ~/work/main/llama-recipes (feature/resume_finetune_peft)]$ torchrun --nnodes 1 --nproc_per_node 2  recipes/finetuning/finetuning.py  --from_peft_checkpoint finetune-output --num_epochs 1 --batch_size_training 4 --use_peft --peft_method lora  --model_name  meta-llama/Meta-Llama-3-8B-Instruct --enable_fsdp --output_dir ./finetune-output
W0521 10:23:35.680000 139849501492224 torch/distributed/run.py:757] 
W0521 10:23:35.680000 139849501492224 torch/distributed/run.py:757] *****************************************
W0521 10:23:35.680000 139849501492224 torch/distributed/run.py:757] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0521 10:23:35.680000 139849501492224 torch/distributed/run.py:757] *****************************************
Clearing GPU cache for all ranks
--> Running with torch dist debug set to detail
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:09<00:00,  2.46s/it]
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
--> Model meta-llama/Meta-Llama-3-8B-Instruct

--> meta-llama/Meta-Llama-3-8B-Instruct has 8030.261248 Million params

Loading checkpoint shards:  75%|██████████████████████████████████████████████████████████████████████████████████▌                           | 3/4 [00:09<00:03,  3.22s/it]trainable params: 20,971,520 || all params: 8,051,232,768 || trainable%: 0.26047588741133265
bFloat16 enabled for mixed precision - using bfSixteen policy
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:10<00:00,  2.67s/it]
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
trainable params: 20,971,520 || all params: 8,051,232,768 || trainable%: 0.26047588741133265
--> applying fsdp activation checkpointing...
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/datasets/load.py:1486: FutureWarning: The repository for samsum contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/samsum
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
--> applying fsdp activation checkpointing...
--> Training Set Length = 14732
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/datasets/load.py:1486: FutureWarning: The repository for samsum contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/samsum
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/datasets/load.py:1486: FutureWarning: The repository for samsum contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/samsum
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
--> Validation Set Length = 818
Preprocessing dataset:  29%|██████████████████████████████▍                                                                          | 4279/14732 [00:00<00:01, 7032.83it/s]/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/datasets/load.py:1486: FutureWarning: The repository for samsum contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/samsum
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
Preprocessing dataset: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6980.73it/s]
Preprocessing dataset: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7196.16it/s]
Preprocessing dataset:  45%|███████████████████████████████████████████████                                                          | 6610/14732 [00:00<00:01, 7217.18it/s]/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/torch/cuda/memory.py:330: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Preprocessing dataset:  85%|████████████████████████████████████████████████████████████████████████████████████████▍               | 12521/14732 [00:01<00:00, 7219.75it/s]NCCL version 2.20.5+cuda12.4
Preprocessing dataset: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 7196.24it/s]
Preprocessing dataset: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7337.65it/s]
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/torch/cuda/memory.py:330: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1/1, step 78/79 completed (loss: 1.0950531959533691): 100%|█████████████████████████████████████████████████████████████████| 79/79 [04:30<00:00,  3.43s/it]
Training Epoch: 1/1, step 78/79 completed (loss: 1.1393404006958008): 100%|█████████████████████████████████████████████████████████████████| 79/79 [04:29<00:00,  3.41s/it]
Max CUDA memory allocated was 45 GB
Max CUDA memory reserved was 54 GB
Peak active CUDA memory was 45 GB
CUDA Malloc retries : 0
CPU Total Peak Memory consumed during the train (max): 9 GB
evaluating Epoch: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17/17 [00:07<00:00,  2.18it/s]
evaluating Epoch: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17/17 [00:07<00:00,  2.19it/s]
 eval_ppl=tensor(2.9572, device='cuda:0') eval_epoch_loss=tensor(1.0842, device='cuda:0')
we are about to save the PEFT modules
PEFT modules are saved in ./finetune-output directory
best eval loss on epoch 1 is 1.0842361450195312
Epoch 1: train_perplexity=2.8781, train_epoch_loss=1.0571, epoch time 271.33888043509796s
Key: avg_train_prep, Value: 2.8780877590179443
Key: avg_train_loss, Value: 1.0571260452270508
Key: avg_eval_prep, Value: 2.9571800231933594
Key: avg_eval_loss, Value: 1.0842361450195312
Key: avg_epoch_time, Value: 271.33888043509796
Key: avg_checkpoint_time, Value: 0.7499661762267351
```
- [x] Finetune with a llama-adapter checkpoint
```
~/work/main/llama-recipes (feature/resume_finetune_peft)]$ python recipes/finetuning/finetuning.py --num_epochs 1 --from_peft_checkpoint finetune-output --batch_size_training 1 --use_peft --peft_method llama-adapter  --model_name  meta-llama/Meta-Llama-3-8B-Instruct --output_dir ./finetune-output
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:02<00:00,  1.95it/s]
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
--> Model meta-llama/Meta-Llama-3-8B-Instruct

--> meta-llama/Meta-Llama-3-8B-Instruct has 8030.261248 Million params

trainable params: 1,228,830 || all params: 8,031,490,078 || trainable%: 0.015300149636815625
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/datasets/load.py:1486: FutureWarning: The repository for samsum contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/samsum
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
--> Training Set Length = 14732
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/datasets/load.py:1486: FutureWarning: The repository for samsum contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/samsum
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
--> Validation Set Length = 818
Preprocessing dataset: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 7138.91it/s]
Preprocessing dataset: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7417.18it/s]
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/torch/cuda/memory.py:330: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1/1, step 398/639 completed (loss: 1.3428374528884888):  62%|██████████████████████████████████████         Training Epoch: 1/1, step 638/639 completed (loss: 1.2846676111221313): 100%|█████████████████████████████████████████████████████████████| 639/639 [37:51<00:00,  3.55s/it]
Max CUDA memory allocated was 69 GB
Max CUDA memory reserved was 70 GB
Peak active CUDA memory was 69 GB
CUDA Malloc retries : 0
CPU Total Peak Memory consumed during the train (max): 8 GB
evaluating Epoch: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 34/34 [00:58<00:00,  1.73s/it]
 eval_ppl=tensor(3.3925, device='cuda:0') eval_epoch_loss=tensor(1.2216, device='cuda:0')
we are about to save the PEFT modules
PEFT modules are saved in ./finetune-output directory
best eval loss on epoch 1 is 1.2215808629989624
Epoch 1: train_perplexity=3.5618, train_epoch_loss=1.2703, epoch time 2271.8472441458143s
Key: avg_train_prep, Value: 3.5617709159851074
Key: avg_train_loss, Value: 1.270257830619812
Key: avg_eval_prep, Value: 3.3925466537475586
Key: avg_eval_loss, Value: 1.2215808629989624
Key: avg_epoch_time, Value: 2271.8472441458143
Key: avg_checkpoint_time, Value: 0.3230209848843515
```
- [x] Finetune without a peft checkpoint
```
~/work/main/llama-recipes (feature/resume_finetune_peft)]$ torchrun --nnodes 1 --nproc_per_node 2  recipes/finetuning/finetuning.py  --num_epochs 1 --batch_size_training 4 --use_peft --peft_method lora  --model_name  meta-llama/Meta-Llama-3-8B-Instruct --enable_fsdp --output_dir ./finetune-output
W0521 10:16:27.114000 140542763557888 torch/distributed/run.py:757] 
W0521 10:16:27.114000 140542763557888 torch/distributed/run.py:757] *****************************************
W0521 10:16:27.114000 140542763557888 torch/distributed/run.py:757] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0521 10:16:27.114000 140542763557888 torch/distributed/run.py:757] *****************************************
Clearing GPU cache for all ranks
--> Running with torch dist debug set to detail
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:09<00:00,  2.45s/it]
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
--> Model meta-llama/Meta-Llama-3-8B-Instruct

--> meta-llama/Meta-Llama-3-8B-Instruct has 8030.261248 Million params

trainable params: 20,971,520 || all params: 8,051,232,768 || trainable%: 0.26047588741133265
bFloat16 enabled for mixed precision - using bfSixteen policy
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:09<00:00,  2.40s/it]
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
trainable params: 20,971,520 || all params: 8,051,232,768 || trainable%: 0.26047588741133265
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/datasets/load.py:1486: FutureWarning: The repository for samsum contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/samsum
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/datasets/load.py:1486: FutureWarning: The repository for samsum contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/samsum
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
Downloading builder script: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3.36k/3.36k [00:00<00:00, 29.1MB/s]
Downloading readme: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7.04k/7.04k [00:00<00:00, 47.1MB/s]
Map: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:00<00:00, 45080.76 examples/s]
Map: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:00<00:00, 44998.82 examples/s]
Map: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:04<00:00, 2998.08 examples/s]
Map: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:05<00:00, 2747.66 examples/s]
--> Training Set Length = 14732
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/datasets/load.py:1486: FutureWarning: The repository for samsum contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/samsum
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/datasets/load.py:1486: FutureWarning: The repository for samsum contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/samsum
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
Map: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 34394.71 examples/s]
Map: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 2998.68 examples/s]
Preprocessing dataset:   5%|█████▎                                                                                                    | 734/14732 [00:00<00:01, 7336.56it/s]--> Validation Set Length = 818
Preprocessing dataset: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 7225.25it/s]
Preprocessing dataset: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7305.61it/s]
Preprocessing dataset: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 7275.76it/s]
Preprocessing dataset: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7542.15it/s]
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/torch/cuda/memory.py:330: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                             | 0/79 [00:00<?, ?it/s]huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
/home/kaiwu/miniconda3/envs/llama/lib/python3.10/site-packages/torch/cuda/memory.py:330: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                             | 0/79 [00:00<?, ?it/s]huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
NCCL version 2.20.5+cuda12.4
Training Epoch: 1/1, step 78/79 completed (loss: 1.151496410369873): 100%|██████████████████████████████████████████████████████████████████| 79/79 [04:34<00:00,  3.48s/it]
Training Epoch: 1/1, step 78/79 completed (loss: 1.1079908609390259): 100%|█████████████████████████████████████████████████████████████████| 79/79 [04:34<00:00,  3.48s/it]
Max CUDA memory allocated was 45 GB
Max CUDA memory reserved was 54 GB
Peak active CUDA memory was 45 GB
CUDA Malloc retries : 0
CPU Total Peak Memory consumed during the train (max): 9 GB
evaluating Epoch:   0%|                                                                                                                              | 0/17 [00:00<?, ?it/s]huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
evaluating Epoch: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17/17 [00:07<00:00,  2.26it/s]
evaluating Epoch: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17/17 [00:07<00:00,  2.25it/s]
 eval_ppl=tensor(2.9739, device='cuda:0') eval_epoch_loss=tensor(1.0899, device='cuda:0')
we are about to save the PEFT modules
PEFT modules are saved in ./finetune-output directory
best eval loss on epoch 1 is 1.0898709297180176
Epoch 1: train_perplexity=3.2454, train_epoch_loss=1.1772, epoch time 275.21213593892753s
Key: avg_train_prep, Value: 3.24538516998291
Key: avg_train_loss, Value: 1.1772340536117554
Key: avg_eval_prep, Value: 2.9738903045654297
Key: avg_eval_loss, Value: 1.0898709297180176
Key: avg_epoch_time, Value: 275.21213593892753
Key: avg_checkpoint_time, Value: 0.8217994091100991
```


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?  
- [x] Did you write any new necessary tests?

Thanks for contributing 🎉!
