### PR TITLE
Adding Torchtune recipe for fine-tuning

### DIFF
--- a/recipes/quickstart/Finetuning/torchtune.md
+++ b/recipes/quickstart/Finetuning/torchtune.md
@@ -9,7 +9,7 @@ torchtune provides:
 - YAML configs for easily configuring training, evaluation, quantization or inference recipes
 - Built-in support for many popular dataset formats and prompt templates to help you quickly get started with training
 
-Here we will show the how to use torchtune to easily finetune meta Llama 3. For more usage details, please check the[torchtune repo](https://github.com/pytorch/torchtune/tree/main).
+Here we will show the how to use torchtune to easily finetune meta Llama 3. For more usage details, please check the [torchtune repo](https://github.com/pytorch/torchtune/tree/main).
 
 ## Installation
 
@@ -100,7 +100,7 @@ Full 8B
 tune run full_finetune_single_device --config llama3/8B_full_single_device
 ```
 
-### Multi GPU
+### Multi GPU finetune
 
 Full 8B
 

--- a/recipes/quickstart/finetune/torchtune.md
+++ b/recipes/quickstart/finetune/torchtune.md
@@ -1,0 +1,133 @@
+# torchtune recipe for Meta Llama 3 finetuning
+
+torchtune is a PyTorch-native library for easily authoring, fine-tuning and experimenting with LLMs.
+
+torchtune provides:
+
+- Native-PyTorch implementations of popular LLMs using composable and modular building blocks
+- Easy-to-use and hackable training recipes for popular fine-tuning techniques (LoRA, QLoRA) - no trainers, no frameworks, just PyTorch!
+- YAML configs for easily configuring training, evaluation, quantization or inference recipes
+- Built-in support for many popular dataset formats and prompt templates to help you quickly get started with training
+
+Here we will show the how to use torchtune to easily finetune meta Llama 3. For more usage details, please check the[torchtune repo](https://github.com/pytorch/torchtune/tree/main).
+
+## Installation
+
+**Step 1:** [Install PyTorch](https://pytorch.org/get-started/locally/). torchtune is tested with the latest stable PyTorch release as well as the preview nightly version.
+
+**Step 2:** The latest stable version of torchtune is hosted on PyPI and can be downloaded with the following command:
+
+```bash
+pip install torchtune
+```
+
+To confirm that the package is installed correctly, you can run the following command:
+
+```bash
+tune --help
+```
+
+And should see the following output:
+
+```bash
+usage: tune [-h] {ls,cp,download,run,validate} ...
+
+Welcome to the torchtune CLI!
+
+options:
+  -h, --help            show this help message and exit
+
+...
+```
+
+You can also install the latest and greatest torchtune has to offer by [installing a nightly build](https://pytorch.org/torchtune/main/install.html).
+
+&nbsp;
+
+---
+
+
+&nbsp;
+
+## Meta Llama3 fine-tuning steps
+
+torchtune supports fine-tuning for the Llama3 8B and 70B size models. It currently support LoRA, QLoRA and full fine-tune on a single GPU as well as LoRA and full fine-tune on multiple devices for the 8B model, and LoRA on multiple devices for the 70B model. For all the details, take a look at the [tutorial](https://pytorch.org/torchtune/main/tutorials/llama3.html).
+
+
+**Note**: The Llama3 LoRA and QLoRA configs default to the instruct fine-tuned models.
+This is because not all special token embeddings are initialized in the base 8B and 70B models.
+
+In the initial experiments for Llama3-8B, QLoRA has a peak allocated memory of ``~9GB`` while LoRA on a single GPU has a peak allocated memory of ``~19GB``. To get started, you can use the default configs to kick off training.
+
+
+### Torchtune repo download
+We need to clone the torchtune repo to get the configs.
+
+```bash
+git clone git@github.com:pytorch/torchtune.git
+cd torchtune/recipes/configs/
+```
+
+### Model download
+Select which model you want to download, in this example we want to use meta-llama/Meta-Llama-3-8B.
+```bash
+tune download meta-llama/Meta-Llama-3-8B \
+--output-dir /tmp/Meta-Llama-3-8B \
+--hf-token <HF_TOKEN> \
+```
+
+
+> Tip: Set your environment variable `HF_TOKEN` or pass in `--hf-token` to the command in order to validate your access.
+You can find your token at https://huggingface.co/settings/tokens
+
+### Single GPU finetune
+
+LoRA 8B
+
+```bash
+tune run lora_finetune_single_device --config llama3/8B_lora_single_device
+```
+
+QLoRA 8B
+
+```bash
+tune run lora_finetune_single_device --config llama3/8B_qlora_single_device
+```
+
+Full 8B
+
+```bash
+tune run full_finetune_single_device --config llama3/8B_full_single_device
+```
+
+### Multi GPU
+
+Full 8B
+
+```bash
+tune run --nproc_per_node 4 full_finetune_distributed --config llama3/8B_full
+```
+
+LoRA 8B
+
+```bash
+tune run --nproc_per_node 2 lora_finetune_distributed --config llama3/8B_lora
+```
+
+LoRA 70B
+
+Note that the download command for the Meta-Llama3 70B model slightly differs from download commands for the 8B models. This is because it use the HuggingFace [safetensor](https://huggingface.co/docs/safetensors/en/index) model format to load the model. To download the 70B model, run
+```bash
+tune download meta-llama/Meta-Llama-3-70b --hf-token <> --output-dir /tmp/Meta-Llama-3-70b --ignore-patterns "original/consolidated*"
+```
+
+Then, a finetune can be kicked off:
+
+```bash
+tune run --nproc_per_node 8 lora_finetune_distributed --config recipes/configs/llama3/70B_lora.yaml
+```
+
+You can find a full list of all the Llama3 configs [here](https://github.com/pytorch/torchtune/tree/main/recipes/configs/llama3).
+
+
+&nbsp;


### PR DESCRIPTION
# What does this PR do?

Adding Torchtune recipe for fine-tuning so that the users can now use torchtune to fine-tune Llama models

## Feature/Issue validation/testing



- [ ] Followed this document to use torchtune.
```
~/work/torchtune/recipes/configs (main)]$ tune run lora_finetune_single_device --config llama3/8B_qlora_single_device
INFO:torchtune.utils.logging:Running LoRAFinetuneRecipeSingleDevice with resolved config:

batch_size: 2
checkpointer:
  _component_: torchtune.utils.FullModelMetaCheckpointer
  checkpoint_dir: /tmp/Meta-Llama-3-8B/original/
  checkpoint_files:
  - consolidated.00.pth
  model_type: LLAMA3
  output_dir: /tmp/Meta-Llama-3-8B/
  recipe_checkpoint: null
compile: false
dataset:
  _component_: torchtune.datasets.alpaca_cleaned_dataset
  train_on_input: true
device: cuda
dtype: bf16
enable_activation_checkpointing: true
epochs: 1
gradient_accumulation_steps: 16
log_every_n_steps: 1
loss:
  _component_: torch.nn.CrossEntropyLoss
lr_scheduler:
  _component_: torchtune.modules.get_cosine_schedule_with_warmup
  num_warmup_steps: 100
max_steps_per_epoch: null
metric_logger:
  _component_: torchtune.utils.metric_logging.DiskLogger
  log_dir: /tmp/qlora_finetune_output/
model:
  _component_: torchtune.models.llama3.qlora_llama3_8b
  apply_lora_to_mlp: true
  apply_lora_to_output: false
  lora_alpha: 16
  lora_attn_modules:
  - q_proj
  - v_proj
  - k_proj
  - output_proj
  lora_rank: 8
optimizer:
  _component_: torch.optim.AdamW
  lr: 0.0003
  weight_decay: 0.01
output_dir: /tmp/qlora_finetune_output/
profiler:
  _component_: torchtune.utils.profiler
  enabled: false
resume_from_checkpoint: false
seed: null
shuffle: true
tokenizer:
  _component_: torchtune.models.llama3.llama3_tokenizer
  path: /tmp/Meta-Llama-3-8B/original/tokenizer.model

DEBUG:torchtune.utils.logging:Setting manual seed to local seed 4023430205. Local seed is seed + rank = 4023430205 + 0
Writing logs to /tmp/qlora_finetune_output/log_1717628124.txt
INFO:torchtune.utils.logging:Model is initialized with precision torch.bfloat16.
INFO:torchtune.utils.logging:Memory Stats after model init:
{'peak_memory_active': 10.126081536, 'peak_memory_alloc': 10.126081536, 'peak_memory_reserved': 12.639535104}
INFO:torchtune.utils.logging:Tokenizer is initialized from file.
INFO:torchtune.utils.logging:Optimizer and loss are initialized.
INFO:torchtune.utils.logging:Loss is initialized.
Downloading readme: 100%|██████████████████████████████████████████████████████████████| 11.6k/11.6k [00:00<00:00, 56.7MB/s]
Downloading data: 100%|████████████████████████████████████████████████████████████████| 44.3M/44.3M [00:00<00:00, 88.3MB/s]
Generating train split: 51760 examples [00:00, 214648.47 examples/s]
INFO:torchtune.utils.logging:Dataset and Sampler are initialized.
INFO:torchtune.utils.logging:Learning rate scheduler is initialized.
1|33|Loss: 1.6673557758331299:   0%|                                                   | 32/25880 [00:24<5:37:10,  1.28it/s]1|33|Loss: 1.6673557758331299:   0%|                                                   | 32/25880 [00:25<5:38:58,  1.27it/s]
```



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?


