### PR TITLE
Corrected wrong order of commands

### DIFF
--- a/recipes/quickstart/Getting_to_know_Llama.ipynb
+++ b/recipes/quickstart/Getting_to_know_Llama.ipynb
@@ -1013,8 +1013,8 @@
    "source": [
     "# This time your previous question and answer will be included as a chat history which will enable the ability\n",
     "# to ask follow up questions.\n",
-    "chat_history = [(query, result[\"answer\"])]\n",
     "query = \"What two sizes?\"\n",
+    "chat_history = [(query, result[\"answer\"])]\n",
     "result = chain({\"question\": query, \"chat_history\": chat_history})\n",
     "md(result['answer'])"
    ]


### PR DESCRIPTION
In the notebook, under section 4.3.2, LangChain Q&A Retriever, the code block where we test chat history has two commands switched in order, resulting in an error while running. Switching to have the "query" variable set first fixes this issue.

# What does this PR do?
This PR switches two lines of code, with one meant to run before the other. The 

## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
