### PR TITLE
Add PromptGuard to safety_utils

### DIFF
--- a/recipes/quickstart/inference/code_llama/code_completion_example.py
+++ b/recipes/quickstart/inference/code_llama/code_completion_example.py
@@ -34,6 +34,7 @@ def main(
     enable_sensitive_topics: bool=False, # Enable check for sensitive topics using AuditNLG APIs
     enable_salesforce_content_safety: bool=True, # Enable safety check with Salesforce safety flan t5
     enable_llamaguard_content_safety: bool=False, # Enable safety check with Llama-Guard
+    enable_promptguard_safety: bool = False,
     use_fast_kernels: bool = True, # Enable using SDPA from PyTroch Accelerated Transformers, make use Flash Attention and Xformer memory-efficient kernels
     **kwargs
 ):
@@ -62,6 +63,7 @@ def main(
                                         enable_sensitive_topics,
                                         enable_salesforce_content_safety,
                                         enable_llamaguard_content_safety,
+                                        enable_promptguard_safety,
                                         )
 
     # Safety check of the user prompt

--- a/recipes/quickstart/inference/code_llama/code_infilling_example.py
+++ b/recipes/quickstart/inference/code_llama/code_infilling_example.py
@@ -33,6 +33,7 @@ def main(
     enable_sensitive_topics: bool=False, # Enable check for sensitive topics using AuditNLG APIs
     enable_salesforce_content_safety: bool=True, # Enable safety check with Salesforce safety flan t5
     enable_llamaguard_content_safety: bool=False, # Enable safety check with Llama-Guard
+    enable_promptguard_safety: bool = False,
     use_fast_kernels: bool = True, # Enable using SDPA from PyTroch Accelerated Transformers, make use Flash Attention and Xformer memory-efficient kernels
     **kwargs
 ):
@@ -62,6 +63,7 @@ def main(
                                         enable_sensitive_topics,
                                         enable_salesforce_content_safety,
                                         enable_llamaguard_content_safety,
+                                        enable_promptguard_safety
                                         )
 
     # Safety check of the user prompt

--- a/recipes/quickstart/inference/code_llama/code_instruct_example.py
+++ b/recipes/quickstart/inference/code_llama/code_instruct_example.py
@@ -71,6 +71,7 @@ def main(
     enable_sensitive_topics: bool=False, # Enable check for sensitive topics using AuditNLG APIs
     enable_salesforce_content_safety: bool=True, # Enable safety check with Salesforce safety flan t5
     enable_llamaguard_content_safety: bool=False, # Enable safety check with Llama-Guard
+    enable_promptguard_safety: bool = False,
     use_fast_kernels: bool = True, # Enable using SDPA from PyTroch Accelerated Transformers, make use Flash Attention and Xformer memory-efficient kernels
     **kwargs
 ):
@@ -95,6 +96,7 @@ def main(
                                         enable_sensitive_topics,
                                         enable_salesforce_content_safety,
                                         enable_llamaguard_content_safety,
+                                        enable_promptguard_safety
                                         )
 
     # Safety check of the user prompt

--- a/recipes/quickstart/inference/local_inference/chat_completion/chat_completion.py
+++ b/recipes/quickstart/inference/local_inference/chat_completion/chat_completion.py
@@ -37,6 +37,7 @@ def main(
     enable_saleforce_content_safety: bool=True, # Enable safety check woth Saleforce safety flan t5
     use_fast_kernels: bool = False, # Enable using SDPA from PyTorch Accelerated Transformers, make use Flash Attention and Xformer memory-efficient kernels
     enable_llamaguard_content_safety: bool = False,
+    enable_promptguard_safety: bool = False,
     **kwargs
 ):
     if prompt_file is not None:
@@ -81,6 +82,7 @@ def main(
                                         enable_sensitive_topics,
                                         enable_saleforce_content_safety,
                                         enable_llamaguard_content_safety,
+                                        enable_promptguard_safety
                                         )
             # Safety check of the user prompt
             safety_results = [check(dialogs[idx][0]["content"]) for check in safety_checker]

--- a/recipes/quickstart/inference/local_inference/inference.py
+++ b/recipes/quickstart/inference/local_inference/inference.py
@@ -36,6 +36,7 @@ def main(
     enable_sensitive_topics: bool = False,  # Enable check for sensitive topics using AuditNLG APIs
     enable_salesforce_content_safety: bool = True,  # Enable safety check with Salesforce safety flan t5
     enable_llamaguard_content_safety: bool = False,
+    enable_promptguard_safety: bool = False,
     max_padding_length: int = None,  # the max padding length to be used with tokenizer padding the prompts.
     use_fast_kernels: bool = False,  # Enable using SDPA from PyTroch Accelerated Transformers, make use Flash Attention and Xformer memory-efficient kernels
     share_gradio: bool = False,  # Enable endpoint creation for gradio.live
@@ -70,7 +71,9 @@ def main(
             enable_sensitive_topics,
             enable_salesforce_content_safety,
             enable_llamaguard_content_safety,
+            enable_promptguard_safety,
         )
+
 
         # Safety check of the user prompt
         safety_results = [check(user_prompt) for check in safety_checker]
@@ -119,9 +122,9 @@ def main(
 
         # Safety check of the model output
         safety_results = [
-            check(output_text, agent_type=AgentType.AGENT, user_prompt=user_prompt)
-            for check in safety_checker
+            check(output_text, agent_type=AgentType.AGENT, user_prompt=user_prompt) for check in safety_checker
         ]
+        print(safety_results)
         are_safe = all([r[1] for r in safety_results])
         if are_safe:
             print("User input and model output deemed safe.")


### PR DESCRIPTION
 [PromptGuard](https://github.com/meta-llama/PurpleLlama/tree/main/Prompt-Guard) has been introduced as a system safety tool to be used to check LLM prompts for malicious text. This PR adds this guard to the safety_utils module and adjusts recipes to use this new check. 

- Implementation details
  - PromptGuard has a limit of 512 tokens. Naive sentence splitting is performed on inputs to try to ensure that this limit is not breached. A warning is printed if a sentence is longer than 512 tokens. 
  - Only the jailbreak score of PromptGuard is acted on. The other scores are intended to be used in agentic implemetations, of which there are none currently which use the safety_utils module. 

General simple test
```
echo "hello" |python3 inference.py "meta-llama/Meta-Llama-3.1-8B-Instruct"  --quantization '8bit' --use_fast_kernels --enable-promptguard-safety True 
```

To test the text splitter feature
```
python3 inference.py "meta-llama/Meta-Llama-3.1-8B-Instruct"  --quantization '8bit' --use_fast_kernels --enable-promptguard-safety True < ~/longprompt 
```