### PR TITLE
Fill in one sentence in the prompt guard tutorial.

### DIFF
--- a/recipes/responsible_ai/prompt_guard/prompt_guard_tutorial.ipynb
+++ b/recipes/responsible_ai/prompt_guard/prompt_guard_tutorial.ipynb
@@ -789,7 +789,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "One good way to quickly obtain labeled training data for a use case is to use the original, non-fine tuned model itself to highlight risky examples to label, while drawing random negatives from below a score threshold. This helps address the class imbalance (attacks and risky prompts can be a very small percentage of all prompts) and includes false positive examples (which tend to be very valuable to train on) in the dataset. The use of synthetic data for specific "
+    "One good way to quickly obtain labeled training data for a use case is to use the original, non-fine tuned model itself to highlight risky examples to label, while drawing random negatives from below a score threshold. This helps address the class imbalance (attacks and risky prompts can be a very small percentage of all prompts) and includes false positive examples (which tend to be very valuable to train on) in the dataset. Generating synthetic fine-tuning data for specific use cases can also be an effective strategy."
    ]
   }
  ],


### PR DESCRIPTION
Simply fills in a single sentence from the tutorial, no functionality impact.

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

