### PR TITLE
recipes/quickstart/Getting_to_know_Llama.ipynb,  typo fix lama -> llama line 127

### DIFF
--- a/recipes/quickstart/Getting_to_know_Llama.ipynb
+++ b/recipes/quickstart/Getting_to_know_Llama.ipynb
@@ -124,7 +124,7 @@
     "      llama-3-1-8b --> llama-3-1-8b-instruct\n",
     "      llama-3-1-70b --> llama-3-1-70b\n",
     "      llama-3-1-70b --> llama-3-1-70b-instruct\n",
-    "      lama-3-1-405b --> llama-3-1-405b-instruct\n",
+    "      llama-3-1-405b --> llama-3-1-405b-instruct\n",
     "      classDef default fill:#CCE6FF,stroke:#84BCF5,textColor:#1C2B33,fontFamily:trebuchet ms;\n",
     "  \"\"\")\n",
     "\n",


### PR DESCRIPTION
# What does this PR do?

in line 127 of llama-recipes/recipes/quickstart/Getting_to_know_Llama.ipynb, it says 

lama-3-1-405b --> llama-3-1-405b-instruct,

instead of 

llama-3-1-405b --> llama-3-1-405b-instruct,


<!-- Remove if not applicable -->




## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
