### PR TITLE
fix AutoModel and bump transformers version to 4.45

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ black[jupyter]
 datasets
 fire
 peft
-transformers>=4.43.1
+transformers>=4.45.0
 sentencepiece
 py7zr
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ black[jupyter]
 datasets
 fire
 peft
-transformers>=4.45.0
+transformers>=4.45.1
 sentencepiece
 py7zr
 scipy

--- a/src/llama_recipes/finetuning.py
+++ b/src/llama_recipes/finetuning.py
@@ -21,8 +21,8 @@ from transformers import (
     AutoTokenizer,
     BitsAndBytesConfig,
     AutoProcessor, 
+    LlamaForCausalLM,
     MllamaForConditionalGeneration,
-    AutoModel,
 )
 from transformers.models.llama.modeling_llama import LlamaDecoderLayer
 from transformers.models.mllama.modeling_mllama import  MllamaSelfAttentionDecoderLayer,MllamaCrossAttentionDecoderLayer,MllamaVisionEncoderLayer
@@ -132,9 +132,11 @@ def main(**kwargs):
     )
         processor = AutoProcessor.from_pretrained(train_config.model_name if train_config.tokenizer_name is None else train_config.tokenizer_name)
         processor.tokenizer.padding_side='right'
+        model.supports_gradient_checkpointing = True
+        model.language_model.supports_gradient_checkpointing = True
     elif config.model_type == "llama":
         is_vision = False
-        model = AutoModel.from_pretrained(
+        model = LlamaForCausalLM.from_pretrained(
             train_config.model_name,
             quantization_config=bnb_config,
             use_cache=use_cache,


### PR DESCRIPTION
# What does this PR do?
fix AutoModel bug in finetune.py and bump transformers version to 4.45 to add mllama support. However, now transformer 4.45.0 pip package did not work as stated in [this issue](https://github.com/huggingface/transformers/issues/33706), we need to wait for [this PR](https://github.com/huggingface/transformers/commit/46841d3eb24f444fc06b7402c273cb51a097c383) to be included the next Transformers pip package to get the mllama Processor working again.

Update:
transformers version 4.45.1 has been released, bumping to this version works
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Please include a good title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] 8B samsum_dataset FSDP+LORA working
```torchrun --nnodes 1 --nproc_per_node 6  recipes/quickstart/finetuning/finetuning.py --use_peft --enable_
fsdp --peft_method lora  --model_name meta-llama/Meta-Llama-3-8B-Instruct --output_dir chatbot-prefix --num_epochs 10 --batch_size_training 1  --run_validation True --flop_counte
r --flop_counter_start 4 --max_train_step 6 --max_eval_step 2 --samsum_dataset.trust_remote_code=True
W0926 10:00:56.395000 140478447821824 torch/distributed/run.py:779] 
W0926 10:00:56.395000 140478447821824 torch/distributed/run.py:779] *****************************************
W0926 10:00:56.395000 140478447821824 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0926 10:00:56.395000 140478447821824 torch/distributed/run.py:779] *****************************************
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
Clearing GPU cache for all ranks
--> Running with torch dist debug set to detail
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  5.29it/s]
--> Model meta-llama/Meta-Llama-3-8B-Instruct

--> meta-llama/Meta-Llama-3-8B-Instruct has 8030.261248 Million params

Loading checkpoint shards:   0%|                                                                                                                            | 0/4 [00:00<?, ?it/s]trainable params: 3,407,872 || all params: 8,033,669,120 || trainable%: 0.0424
bFloat16 enabled for mixed precision - using bfSixteen policy
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  8.48it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  5.12it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  5.28it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  4.63it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  4.74it/s]
trainable params: 3,407,872 || all params: 8,033,669,120 || trainable%: 0.0424
trainable params: 3,407,872 || all params: 8,033,669,120 || trainable%: 0.0424
trainable params: 3,407,872 || all params: 8,033,669,120 || trainable%: 0.0424
trainable params: 3,407,872 || all params: 8,033,669,120 || trainable%: 0.0424
trainable params: 3,407,872 || all params: 8,033,669,120 || trainable%: 0.0424
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> Training Set Length = 14732
Preprocessing dataset:   0%|                                                                                                                            | 0/14732 [00:00<?, ?it/s]--> Validation Set Length = 818
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6862.88it/s]
length of dataset_train 639
--> Num of Training Set Batches loaded = 106
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6874.49it/s]
length of dataset_train 639
--> Num of Training Set Batches loaded = 106
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6683.56it/s]
length of dataset_train 639
--> Num of Training Set Batches loaded = 106
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 6961.71it/s]
--> Num of Validation Set Batches loaded = 5
--> Num of Validation Set Batches loaded = 5
Starting epoch 0/10
train_config.max_train_step: 6
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7073.52it/s]
--> Num of Validation Set Batches loaded = 5
--> Num of Validation Set Batches loaded = 5
Starting epoch 0/10
train_config.max_train_step: 6
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 6908.40it/s]
--> Num of Validation Set Batches loaded = 5
--> Num of Validation Set Batches loaded = 5
Starting epoch 0/10
train_config.max_train_step: 6
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6865.71it/s]
length of dataset_train 639
--> Num of Training Set Batches loaded = 106
Preprocessing dataset:  96%|█████████████████████████████████████████████████████████████████████████████████████████████████████████▍    | 14129/14732 [00:02<00:00, 6755.05it/s]/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/106 [00:00<?, ?it/s]/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/106 [00:00<?, ?it/s]/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6892.91it/s]
length of dataset_train 639
--> Num of Training Set Batches loaded = 106
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7046.51it/s]
--> Num of Validation Set Batches loaded = 5
--> Num of Validation Set Batches loaded = 5
Starting epoch 0/10
train_config.max_train_step: 6
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7031.75it/s]
--> Num of Validation Set Batches loaded = 5
--> Num of Validation Set Batches loaded = 5
Starting epoch 0/10
train_config.max_train_step: 6
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6854.20it/s]
length of dataset_train 639
--> Num of Training Set Batches loaded = 106
Preprocessing dataset:   0%|                                                                                                                              | 0/818 [00:00<?, ?it/s]/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/106 [00:00<?, ?it/s]NCCL version 2.20.5+cuda12.4
Preprocessing dataset:  86%|██████████████████████████████████████████████████████████████████████████████████████████████████▎               | 705/818 [00:00<00:00, 7043.56it/s]/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7014.57it/s]
--> Num of Validation Set Batches loaded = 5
--> Num of Validation Set Batches loaded = 5
Starting epoch 0/10
train_config.max_train_step: 6
Training Epoch: 1:   0%|                                                                                                                                  | 0/106 [00:00<?, ?it/s]/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/106 [00:00<?, ?it/s]/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
Training Epoch: 1/10, step 4/106 completed (loss: 1.6060208082199097):   6%|███▉                                                                  | 6/106 [00:25<05:19,  3.20s/it]max training steps reached, stopping training, total train steps finished:  6
Training Epoch: 1/10, step 5/106 completed (loss: 1.4604358673095703):   6%|███▉                                                                  | 6/106 [00:25<06:57,  4.17s/it]
Training Epoch: 1/10, step 5/106 completed (loss: 1.4065511226654053):   6%|███▉                                                                  | 6/106 [00:25<07:11,  4.32s/it]
Training Epoch: 1/10, step 5/106 completed (loss: 1.3868926763534546):   6%|███▉                                                                  | 6/106 [00:25<07:06,  4.26s/it]
Training Epoch: 1/10, step 5/106 completed (loss: 1.4889317750930786):   6%|███▉                                                                  | 6/106 [00:25<07:12,  4.32s/it]
Total time used in this flop counting step is: 2.6097419261932373
The total TFlop per second is: 103.62345261768849
The tflop_count table is below:
Module                                                     FLOP    % Total
-----------------------------------------------------  --------  ---------
FullyShardedDataParallel                               270.430T    100.00%
 - aten.bmm                                              0.000T      0.00%
 - aten.mm                                             222.052T     82.11%
 - aten._scaled_dot_product_flash_attention             26.388T      9.76%
 - aten._scaled_dot_product_flash_attention_backward    21.990T      8.13%
 FullyShardedDataParallel._fsdp_wrapped_module         270.430T    100.00%
  - aten.bmm                                             0.000T      0.00%
  - aten.mm                                            222.052T     82.11%
  - aten._scaled_dot_product_flash_attention            26.388T      9.76%
  - aten._scaled_dot_product_flash_attention_backward   21.990T      8.13%
Training Epoch: 1/10, step 5/106 completed (loss: 1.3996834754943848):   6%|███▉                                                                  | 6/106 [00:25<07:12,  4.33s/it]
Training Epoch: 1/10, step 5/106 completed (loss: 1.3902316093444824):   6%|███▉                                                                  | 6/106 [00:25<07:04,  4.25s/it]
Max CUDA memory allocated was 84 GB
Max CUDA memory reserved was 85 GB
Peak active CUDA memory was 84 GB
CUDA Malloc retries : 0
CPU Total Peak Memory consumed during the train (max): 9 GB
evaluating Epoch:  40%|██████████████████████████████████████████████████                                                                           | 2/5 [00:00<00:01,  2.78it/s]max eval steps reached, stopping evaluation, total_eval_steps:  2
evaluating Epoch:  40%|██████████████████████████████████████████████████                                                                           | 2/5 [00:00<00:01,  2.44it/s]
evaluating Epoch:  40%|██████████████████████████████████████████████████                                                                           | 2/5 [00:00<00:01,  2.70it/s]
evaluating Epoch:  40%|██████████████████████████████████████████████████                                                                           | 2/5 [00:00<00:01,  2.82it/s]
evaluating Epoch:  40%|██████████████████████████████████████████████████                                                                           | 2/5 [00:00<00:01,  2.29it/s]
evaluating Epoch:  40%|██████████████████████████████████████████████████                                                                           | 2/5 [00:00<00:01,  2.27it/s]
evaluating Epoch:  40%|██████████████████████████████████████████████████                                                                           | 2/5 [00:00<00:01,  2.34it/s]
 eval_ppl=tensor(1.7234, device='cuda:0') eval_epoch_loss=tensor(0.5443, device='cuda:0')
we are about to save the PEFT modules
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:689: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html .
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:689: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html .
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:689: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html .
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:689: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html .
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:689: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html .
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:689: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html .
  warnings.warn(
PEFT modules are saved in chatbot-prefix directory
best eval loss on epoch 1 is 0.5443158149719238
Epoch 1: train_perplexity=1.0946, train_epoch_loss=0.0904, epoch time 26.56355979386717s
Starting epoch 1/10
train_config.max_train_step: 6
Starting epoch 1/10
train_config.max_train_step: 6
Starting epoch 1/10
train_config.max_train_step: 6
Starting epoch 1/10
train_config.max_train_step: 6
Starting epoch 1/10
train_config.max_train_step: 6
Starting epoch 1/10
train_config.max_train_step: 6
Key: avg_train_prep, Value: 1.0945931673049927
Key: avg_train_loss, Value: 0.09038276970386505
Key: avg_eval_prep, Value: 1.7234288454055786
Key: avg_eval_loss, Value: 0.5443158149719238
Key: avg_epoch_time, Value: 26.56355979386717
Key: avg_checkpoint_time, Value: 12.235354381147772
Key: model_tflops, Value: 103.62345261768849
```

- [x] 11B FSDP+LORA works on OCRVQA
```torchrun --nnodes 1 --nproc_per_node 4  recipes/quickstart/finetuning/finetuning.py --enable_fsdp --lr 2e-5 --context_length 8192 --num_epochs 3 --batch_size_training 2 --model_name meta-llama/Llama-3.2-11B-Vision-Instruct --dist_checkpoint_root_folder /home/kaiwu/work/fb_connect/finetune_11bmodel --dist_checkpoint_folder fine-tuned  --use_fast_kernels --dataset "custom_dataset" --custom_dataset.test_split "test" --custom_dataset.file "recipes/quickstart/finetuning/datasets/ocrvqa_dataset.py"  --run_validation True --batching_strategy padding  --use_peft --peft_method lora --flop_counter --flop_counter_start 4 --max_train_step 6 --max_eval_step 2
W0926 10:03:16.057000 140504509277184 torch/distributed/run.py:779] 
W0926 10:03:16.057000 140504509277184 torch/distributed/run.py:779] *****************************************
W0926 10:03:16.057000 140504509277184 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0926 10:03:16.057000 140504509277184 torch/distributed/run.py:779] *****************************************
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
Clearing GPU cache for all ranks
--> Running with torch dist debug set to detail
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00,  7.27it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  4.82it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  4.78it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  3.59it/s]
--> Model meta-llama/Llama-3.2-11B-Vision-Instruct

--> meta-llama/Llama-3.2-11B-Vision-Instruct has 10670.220835 Million params

trainable params: 5,898,240 || all params: 10,676,119,075 || trainable%: 0.0552
bFloat16 enabled for mixed precision - using bfSixteen policy
trainable params: 5,898,240 || all params: 10,676,119,075 || trainable%: 0.0552
trainable params: 5,898,240 || all params: 10,676,119,075 || trainable%: 0.0552
trainable params: 5,898,240 || all params: 10,676,119,075 || trainable%: 0.0552
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> Training Set Length = 1800
--> Validation Set Length = 200
length of dataset_train 1800
custom_data_collator is used
--> Num of Training Set Batches loaded = 225
length of dataset_train 1800
custom_data_collator is used
--> Num of Training Set Batches loaded = 225
--> Num of Validation Set Batches loaded = 50
--> Num of Validation Set Batches loaded = 50
Starting epoch 0/3
train_config.max_train_step: 6
--> Num of Validation Set Batches loaded = 50
--> Num of Validation Set Batches loaded = 50
Starting epoch 0/3
train_config.max_train_step: 6
length of dataset_train 1800
custom_data_collator is used
--> Num of Training Set Batches loaded = 225
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/225 [00:00<?, ?it/s]--> Num of Validation Set Batches loaded = 50
--> Num of Validation Set Batches loaded = 50
Starting epoch 0/3
train_config.max_train_step: 6
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/225 [00:00<?, ?it/s]NCCL version 2.20.5+cuda12.4
length of dataset_train 1800
custom_data_collator is used
--> Num of Training Set Batches loaded = 225
--> Num of Validation Set Batches loaded = 50
--> Num of Validation Set Batches loaded = 50
Starting epoch 0/3
train_config.max_train_step: 6
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/225 [00:00<?, ?it/s]/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:92: UserWarning: None of the inputs have requires_grad=True. Gradients will be None
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:92: UserWarning: None of the inputs have requires_grad=True. Gradients will be None
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:92: UserWarning: None of the inputs have requires_grad=True. Gradients will be None
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:92: UserWarning: None of the inputs have requires_grad=True. Gradients will be None
  warnings.warn(
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
Training Epoch: 1/3, step 5/225 completed (loss: 1.0278592109680176):   3%|█▉                                                                     | 6/225 [00:21<09:49,  2.69s/it]max training steps reached, stopping training, total train steps finished:  6
Training Epoch: 1/3, step 5/225 completed (loss: 1.0278592109680176):   3%|█▉                                                                     | 6/225 [00:21<12:59,  3.56s/it]
Total time used in this flop counting step is: 2.336395263671875
The total TFlop per second is: 25.241005088821396
The tflop_count table is below:
Module                                                        FLOP    % Total
---------------------------------------------------------  -------  ---------
FullyShardedDataParallel                                   58.973T    100.00%
 - aten.convolution                                         0.019T      0.03%
 - aten.bmm                                                 0.000T      0.00%
 - aten.mm                                                 26.474T     44.89%
 - aten._scaled_dot_product_efficient_attention            17.496T     29.67%
 - aten.addmm                                              14.295T     24.24%
 - aten._scaled_dot_product_efficient_attention_backward    0.689T      1.17%
 FullyShardedDataParallel._fsdp_wrapped_module             58.973T    100.00%
  - aten.convolution                                        0.019T      0.03%
  - aten.bmm                                                0.000T      0.00%
  - aten.mm                                                26.474T     44.89%
  - aten._scaled_dot_product_efficient_attention           17.496T     29.67%
  - aten.addmm                                             14.295T     24.24%
  - aten._scaled_dot_product_efficient_attention_backward   0.689T      1.17%
Training Epoch: 1/3, step 5/225 completed (loss: 0.5811285376548767):   3%|█▉                                                                     | 6/225 [00:21<13:00,  3.56s/it]
Training Epoch: 1/3, step 5/225 completed (loss: 0.7257668972015381):   3%|█▉                                                                     | 6/225 [00:19<12:08,  3.33s/it]
Training Epoch: 1/3, step 5/225 completed (loss: 0.5231667757034302):   3%|█▉                                                                     | 6/225 [00:20<12:39,  3.47s/it]
Max CUDA memory allocated was 13 GB
Max CUDA memory reserved was 16 GB
Peak active CUDA memory was 13 GB
CUDA Malloc retries : 0
CPU Total Peak Memory consumed during the train (max): 10 GB
evaluating Epoch:   4%|████▉                                                                                                                       | 2/50 [00:01<00:26,  1.80it/s]max eval steps reached, stopping evaluation, total_eval_steps:  2
evaluating Epoch:   4%|████▉                                                                                                                       | 2/50 [00:01<00:31,  1.52it/s]
evaluating Epoch:   4%|████▉                                                                                                                       | 2/50 [00:01<00:33,  1.42it/s]
evaluating Epoch:   4%|████▉                                                                                                                       | 2/50 [00:01<00:33,  1.42it/s]
evaluating Epoch:   4%|████▉                                                                                                                       | 2/50 [00:01<00:31,  1.52it/s]
 eval_ppl=tensor(1.0339, device='cuda:0') eval_epoch_loss=tensor(0.0333, device='cuda:0')
we are about to save the PEFT modules
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:689: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html .
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:689: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html .
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:689: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html .
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py:689: FutureWarning: FSDP.state_dict_type() and FSDP.set_state_dict_type() are being deprecated. Please use APIs, get_state_dict() and set_state_dict(), which can support different parallelisms, FSDP1, FSDP2, DDP. API doc: https://pytorch.org/docs/stable/distributed.checkpoint.html#torch.distributed.checkpoint.state_dict.get_state_dict .Tutorial: https://pytorch.org/tutorials/recipes/distributed_checkpoint_recipe.html .
  warnings.warn(
PEFT modules are saved in PATH/to/save/PEFT/model directory
Starting epoch 1/3
train_config.max_train_step: 6
Starting epoch 1/3
train_config.max_train_step: 6
Starting epoch 1/3
best eval loss on epoch 1 is 0.03330489993095398train_config.max_train_step: 6

Epoch 1: train_perplexity=1.0229, train_epoch_loss=0.0226, epoch time 22.056724132038653s
Starting epoch 1/3
train_config.max_train_step: 6
Key: avg_train_prep, Value: 1.0228856801986694
Key: avg_train_loss, Value: 0.022627701982855797
Key: avg_eval_prep, Value: 1.0338656902313232
Key: avg_eval_loss, Value: 0.03330489993095398
Key: avg_epoch_time, Value: 22.056724132038653
Key: avg_checkpoint_time, Value: 14.03366973111406
Key: model_tflops, Value: 25.241005088821396
```

- [x] 8B samsum_dataset FSDP+QLORA working
```FSDP_CPU_RAM_EFFICIENT_LOADING=1 ACCELERATE_USE_FSDP=1 torchrun --nnodes 1 --nproc_per_node 4  recipes/quickstart/finetuning/finetuning.py --enable_fsdp  --quantization 4bit --model_name meta-llama/Llama-3.1-70B-Instruct  --mixed_precision False --low_cpu_fsdp --use_peft --peft_method lora --output_dir Path/to/save/PEFT/model --samsum_dataset.trust_remote_code=True
W0926 11:32:56.213000 140228239340544 torch/distributed/run.py:779] 
W0926 11:32:56.213000 140228239340544 torch/distributed/run.py:779] *****************************************
W0926 11:32:56.213000 140228239340544 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0926 11:32:56.213000 140228239340544 torch/distributed/run.py:779] *****************************************
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
Clearing GPU cache for all ranks
--> Running with torch dist debug set to detail
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:23<00:00,  1.27it/s]
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:23<00:00,  1.26it/s]
Loading checkpoint shards:  70%|███████████████████████████████████████████████████████████████████████████████▊                                  | 21/30 [00:25<00:12,  1.35s/it]trainable params: 16,384,000 || all params: 70,570,090,496 || trainable%: 0.0232
trainable params: 16,384,000 || all params: 70,570,090,496 || trainable%: 0.0232
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:24<00:00,  1.20it/s]
Loading checkpoint shards:  73%|███████████████████████████████████████████████████████████████████████████████████▌                              | 22/30 [00:26<00:10,  1.29s/it]trainable params: 16,384,000 || all params: 70,570,090,496 || trainable%: 0.0232
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:34<00:00,  1.15s/it]
--> Model meta-llama/Llama-3.1-70B-Instruct

--> meta-llama/Llama-3.1-70B-Instruct has 2102.665216 Million params

trainable params: 16,384,000 || all params: 70,570,090,496 || trainable%: 0.0232
NCCL version 2.20.5+cuda12.4
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
Map:  24%|█████████████████████████████                                                                                             | 3504/14732 [00:01<00:03, 3030.93 examples/s]--> applying fsdp activation checkpointing...
Map: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:04<00:00, 3020.90 examples/s]
Map: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:04<00:00, 2954.71 examples/s]
Map: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:05<00:00, 2941.05 examples/s]
Map: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 2957.14 examples/s]
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6706.07it/s]
length of dataset_train 639
--> Num of Training Set Batches loaded = 39
Map: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:04<00:00, 3010.72 examples/s]
--> Training Set Length = 14732
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6836.68it/s]
length of dataset_train 639
--> Num of Training Set Batches loaded = 39
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7111.26it/s]
--> Num of Validation Set Batches loaded = 8
--> Num of Validation Set Batches loaded = 8
Starting epoch 0/3
train_config.max_train_step: 0
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6887.25it/s]
length of dataset_train 639
--> Num of Training Set Batches loaded = 39
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 6904.05it/s]
--> Num of Validation Set Batches loaded = 8
--> Num of Validation Set Batches loaded = 8
Starting epoch 0/3
train_config.max_train_step: 0
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7007.97it/s]
--> Num of Validation Set Batches loaded = 8
--> Num of Validation Set Batches loaded = 8
Starting epoch 0/3
train_config.max_train_step: 0
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                   | 0/39 [00:00<?, ?it/s]huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                   | 0/39 [00:00<?, ?it/s]huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                   | 0/39 [00:00<?, ?it/s]huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
--> Validation Set Length = 818
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14732/14732 [00:02<00:00, 6885.90it/s]
length of dataset_train 639
--> Num of Training Set Batches loaded = 39
Preprocessing dataset: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 818/818 [00:00<00:00, 7015.87it/s]
--> Num of Validation Set Batches loaded = 8
--> Num of Validation Set Batches loaded = 8
Starting epoch 0/3
train_config.max_train_step: 0
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                   | 0/39 [00:00<?, ?it/s]huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
Training Epoch: 1/3, step 5/39 completed (loss: 1.2683604955673218):  15%|███████████▏                                                             | 6/39 [02:27<13:11, 24.00s/it]
```

- [x] 11B OCRVQA FSDP+QLORA working
```FSDP_CPU_RAM_EFFICIENT_LOADING=1 ACCELERATE_USE_FSDP=1 torchrun --nnodes 1 --nproc_per_node 4  recipes/quickstart/finetuning/finetuning.py --enable_fsdp  --quantization 4bit --model_name meta-llama/Llama-3.2-11B-Vision-Instruct --dataset "custom_dataset" --custom_dataset.test_split "test" --custom_dataset.file "recipes/quickstart/finetuning/datasets/ocrvqa_dataset.py"   --mixed_precision False --low_cpu_fsdp --use_peft --peft_method lora --output_dir Path/to/save/PEFT/model --batching_strategy padding 
W0926 11:41:41.877000 139964614112256 torch/distributed/run.py:779] 
W0926 11:41:41.877000 139964614112256 torch/distributed/run.py:779] *****************************************
W0926 11:41:41.877000 139964614112256 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0926 11:41:41.877000 139964614112256 torch/distributed/run.py:779] *****************************************
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
/home/kaiwu/work/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
Clearing GPU cache for all ranks
--> Running with torch dist debug set to detail
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:03<00:00,  1.32it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:03<00:00,  1.36it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:03<00:00,  1.34it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:05<00:00,  1.19s/it]
trainable params: 5,898,240 || all params: 10,676,119,075 || trainable%: 0.0552
trainable params: 5,898,240 || all params: 10,676,119,075 || trainable%: 0.0552
trainable params: 5,898,240 || all params: 10,676,119,075 || trainable%: 0.0552
--> Model meta-llama/Llama-3.2-11B-Vision-Instruct

--> meta-llama/Llama-3.2-11B-Vision-Instruct has 1128.179235 Million params

trainable params: 5,898,240 || all params: 10,676,119,075 || trainable%: 0.0552
NCCL version 2.20.5+cuda12.4
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> applying fsdp activation checkpointing...
--> Training Set Length = 1800
--> Validation Set Length = 200
length of dataset_train 1800
custom_data_collator is used
--> Num of Training Set Batches loaded = 112
length of dataset_train 1800
custom_data_collator is used
--> Num of Training Set Batches loaded = 112
length of dataset_train 1800
custom_data_collator is used
--> Num of Training Set Batches loaded = 112
--> Num of Validation Set Batches loaded = 50
--> Num of Validation Set Batches loaded = 50
Starting epoch 0/3
train_config.max_train_step: 0
--> Num of Validation Set Batches loaded = 50
--> Num of Validation Set Batches loaded = 50
Starting epoch 0/3
train_config.max_train_step: 0
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/112 [00:00<?, ?it/s]--> Num of Validation Set Batches loaded = 50
--> Num of Validation Set Batches loaded = 50
Starting epoch 0/3
train_config.max_train_step: 0
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/112 [00:00<?, ?it/s]/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/112 [00:00<?, ?it/s]length of dataset_train 1800
custom_data_collator is used
--> Num of Training Set Batches loaded = 112
--> Num of Validation Set Batches loaded = 50
--> Num of Validation Set Batches loaded = 50
Starting epoch 0/3
train_config.max_train_step: 0
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/cuda/memory.py:343: FutureWarning: torch.cuda.reset_max_memory_allocated now calls torch.cuda.reset_peak_memory_stats, which resets /all/ peak memory stats.
  warnings.warn(
Training Epoch: 1:   0%|                                                                                                                                  | 0/112 [00:00<?, ?it/s]/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:92: UserWarning: None of the inputs have requires_grad=True. Gradients will be None
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:92: UserWarning: None of the inputs have requires_grad=True. Gradients will be None
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:92: UserWarning: None of the inputs have requires_grad=True. Gradients will be None
  warnings.warn(
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:92: UserWarning: None of the inputs have requires_grad=True. Gradients will be None
  warnings.warn(
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
/home/kaiwu/miniconda3/envs/recipe_test/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
Training Epoch: 1/3, step 14/112 completed (loss: 1.0585829019546509):  13%|█████████▏                                                           | 15/112 [00:28<02:40,  1.66s/it]
```
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
