### PR TITLE
[Fixed] RuntimeError: probability tensor contains either inf, nan or element < 0

### DIFF
--- a/recipes/quickstart/inference/local_inference/multi_modal_infer.py
+++ b/recipes/quickstart/inference/local_inference/multi_modal_infer.py
@@ -15,6 +15,7 @@ def load_model_and_processor(model_name: str, hf_token: str):
     Load the model and processor based on the 11B or 90B model.
     """
     model = MllamaForConditionalGeneration.from_pretrained(model_name, device_map="auto", torch_dtype=torch.bfloat16, token=hf_token)
+    model = model.bfloat16().cuda()
     processor = MllamaProcessor.from_pretrained(model_name, token=hf_token)
     return model, processor
 


### PR DESCRIPTION
# What does this PR do?

<!--
On executing the multimodal inferencing there was an error as shown in the title
-->
Issue arises when we ran the following command in directory `recipes/quickstart/inference/`
```
python multi_modal_infer.py --image_path Image.png --prompt_text "Describe this image" --temperature 0.9  --top_p 0.1 --model_name "meta-llama/Llama-3.2-11B-Vision-Instruct" --hf_token <your hf-token>
```
Fixes # (issue)
The issue is fixed by adding the following line:
```
model = model.bfloat16().cuda()
```

## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

-## Test A
- Used command `python multi_modal_infer.py --image_path Image.png --prompt_text "Describe this image" --temperature 0.9  --top_p 0.1 --model_name "meta-llama/Llama-3.2-11B-Vision-Instruct" --hf_token <your hf-token>`
### Logs for Test A

Generated Text: end_header_id|>

The image depicts a cartoon astronaut in a white spacesuit, floating in space. The astronaut is wearing a white spacesuit with a blue and red control panel on the front, and a white helmet with a clear visor. The astronaut has brown hair and is smiling, with their arms outstretched and legs bent at the knees.

*   The astronaut is wearing a white spacesuit with a blue and red control panel on the front.
    *   The control panel has a red button, a yellow button, and a green button.
    *   The astronaut's helmet is white with a clear visor.
    *   The astronaut has brown hair.
*   The background of the image is dark blue, with white and yellow stars scattered throughout.
    *   The stars are of varying sizes and shapes.
    *   Some of the stars have a slight glow effect around them.
*   The overall atmosphere of the image is one of adventure and exploration, with the astronaut floating in space surrounded by stars.

The image suggests that the astronaut is on a mission to explore the vastness of space, and the stars in the background represent the infinite possibilities and wonders that await them.<|eot_id|>

## Test B
-  Used command `python multi_modal_infer.py --image_path Image.png --prompt_text "Describe this image" --temperature 0.9  --top_p 0.1 --model_name "meta-llama/Llama-3.2-11B-Vision-Instruct" --hf_token <your hf-token>`
### Logs for Test B

Generated Text: end_header_id|>

The image presents a close-up photograph of an orange tabby cat, showcasing its distinctive features and surroundings.

* The cat's head is prominently displayed in the foreground, occupying approximately 75% of the image.
        + The cat's fur is a vibrant orange color with white markings on its nose, chin, and whiskers.
        + Its eyes are green, and its ears are perked up, giving it a curious expression.
        + The cat's whiskers are long and white, adding to its overall appearance.
* The background of the image is blurred, but it appears to be a grassy area.
        + The grass is a bright green color, suggesting a sunny day.
        + The background is out of focus, drawing attention to the cat in the foreground.

In summary, the image is a captivating portrait of an orange tabby cat, with its striking features and surroundings creating a visually appealing composition. The cat's curious expression and vibrant fur make it the main focus of the image, while the blurred background adds depth and context to the scene.<|eot_id|>

*Working on Single GPU*
## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
- [x] Was this discussed/approved via a GitHub issue? [issue-683](https://github.com/meta-llama/llama-recipes/issues/683)
- [ ] Did you make sure to update the documentation with your changes?  Not required
- [ ] Did you write any new necessary tests? No

Thanks for contributing 🎉!
