### PR TITLE
add support for llama vision model conversion

### DIFF
--- a/recipes/quickstart/inference/local_inference/README.md
+++ b/recipes/quickstart/inference/local_inference/README.md
@@ -96,6 +96,14 @@ python inference.py --model_name <training_config.output_dir> --prompt_file <tes
 
 ```
 
+Note: if you want to convert llama vision models, set the `multimodal` argument to True, and inference using [multimodal inference](../../../../recipes/quickstart/inference/local_inference/README.md#multimodal-inference).
+```bash
+# convert finetuned model
+python -m llama_recipes.inference.checkpoint_converter_fsdp_hf --fsdp_checkpoint_path  PATH/to/FSDP/Checkpoints --consolidated_model_path PATH/to/save/checkpoints --HF_model_path_or_name PATH/or/HF/model_name --multimodal True
+# multimodal inference
+python multi_modal_infer.py --image_path "./resources/image.jpg" --prompt_text "Describe this image" --temperature 0.5 --top_p 0.8 --model_name PATH/to/save/checkpoints
+```
+
 ## Inference on large models like Meta Llama 405B
 The FP8 quantized variants of Meta Llama (i.e. meta-llama/Meta-Llama-3.1-405B-FP8 and meta-llama/Meta-Llama-3.1-405B-Instruct-FP8) can be executed on a single node with 8x80GB H100 using the scripts located in this folder.
 To run the unquantized Meta Llama 405B variants (i.e. meta-llama/Meta-Llama-3.1-405B and meta-llama/Meta-Llama-3.1-405B-Instruct) we need to use a multi-node setup for inference. The llama-recipes inference script currently does not allow multi-node inference. To run this model you can use vLLM with pipeline and tensor parallelism as showed in [this example](../../../3p_integrations/vllm/README.md).

--- a/src/llama_recipes/inference/checkpoint_converter_fsdp_hf.py
+++ b/src/llama_recipes/inference/checkpoint_converter_fsdp_hf.py
@@ -25,7 +25,8 @@ from model_checkpointing import load_sharded_model_single_gpu
 def main(
     fsdp_checkpoint_path="", # Path to FSDP Sharded model checkpoints
     consolidated_model_path="", # Path to save the HF converted model checkpoints
-    HF_model_path_or_name="" # Path/ name of the HF model that include config.json and tokenizer_config.json (e.g. meta-llama/Llama-2-7b-chat-hf)
+    HF_model_path_or_name="", # Path/ name of the HF model that include config.json and tokenizer_config.json (e.g. meta-llama/Llama-2-7b-chat-hf)
+    multimodal=False # Use MllamaConfig for llama 3.2 vision models
     ):
     
     try:
@@ -50,7 +51,7 @@ def main(
         
         
     #load the HF model definition from config
-    model_def = load_llama_from_config(HF_model_path_or_name)
+    model_def = load_llama_from_config(HF_model_path_or_name, multimodal)
     print("model is loaded from config")
     #load the FSDP sharded checkpoints into the model
     model = load_sharded_model_single_gpu(model_def, fsdp_checkpoint_path)

--- a/src/llama_recipes/inference/model_utils.py
+++ b/src/llama_recipes/inference/model_utils.py
@@ -4,7 +4,7 @@
 from llama_recipes.utils.config_utils import update_config
 from llama_recipes.configs import quantization_config  as QUANT_CONFIG
 from peft import PeftModel
-from transformers import AutoModelForCausalLM, LlamaForCausalLM, LlamaConfig
+from transformers import AutoModelForCausalLM, LlamaForCausalLM, LlamaConfig, MllamaForConditionalGeneration, MllamaConfig
 from warnings import warn
 
 # Function to load the main model for text generation
@@ -41,9 +41,11 @@ def load_peft_model(model, peft_model):
     return peft_model
 
 # Loading the model from config to load FSDP checkpoints into that
-def load_llama_from_config(config_path):
-    model_config = LlamaConfig.from_pretrained(config_path) 
-    model = LlamaForCausalLM(config=model_config)
+def load_llama_from_config(config_path, multimodal):
+    if multimodal:
+        model_config = MllamaConfig.from_pretrained(config_path)
+        model = MllamaForConditionalGeneration(config=model_config)
+    else:
+        model_config = LlamaConfig.from_pretrained(config_path) 
+        model = LlamaForCausalLM(config=model_config)
     return model
-    
-    


### PR DESCRIPTION
# What does this PR do?

Updated the script to support converting finetuned llama 3.2 vision model to HF format, so it works with multimodal inference.

## Feature/Issue validation/testing




Tested following scripts and it works, without the fix it gives conversion error between llama and mllama config.
```
python src/llama_recipes/inference/checkpoint_converter_fsdp_hf.py --fsdp_checkpoint_path  /path/to/finetuned/model --consolidated_model_path  /path/to/save/converted/model  --HF_model_path_or_name /home/ubuntu/llama/Llama-3.2-11B-Vision-Instruct/ --multimodal True

python recipes/quickstart/inference/local_inference/multi_modal_infer.py --image_path  /home/ubuntu/chair.jpg --prompt_text "Describe this image" --temperature 0.5 --top_p 0.8 --model_name finetuned_model_mind2web/fine-tuned-meta-llama/hf_model/ --hf_token HF_TOKEN
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
