### PR TITLE
Fix the bug when continue the peft.

### DIFF
--- a/src/llama_recipes/finetuning.py
+++ b/src/llama_recipes/finetuning.py
@@ -167,7 +167,7 @@ def main(**kwargs):
         # Load the pre-trained peft model checkpoint and setup its configuration
         if train_config.from_peft_checkpoint:
             model = PeftModel.from_pretrained(model, train_config.from_peft_checkpoint, is_trainable=True)
-            peft_config = model.peft_config()
+            peft_config = model.peft_config
         # Generate the peft config and start fine-tuning from original model
         else:
             peft_config = generate_peft_config(train_config, kwargs)


### PR DESCRIPTION

# What does this PR do?
Fixed a bug when loading a peft llama-3-8b-instruct checkpoint to continue the finetuning. 
The parameter passed to peft_config is modified, which means the `()` of `peft_config = model.peft_config()` has been removed.

Fixes #709 


## Feature/Issue validation/testing


- [X] Test 
Run the `/recipes/quickstart/finetuning/finetuning.py` after the modification in `/src/llama_recipes/finetuning.py`, with the config `from_peft_checkpoint: str="/root/lora-llama3-ft/save/PEFT/model_ner_in_assis"`
Logs:
```
/root/llama-recipes/src/llama_recipes/model_checkpointing/checkpoint_handler.py:17: DeprecationWarning: `torch.distributed._shard.checkpoint` will be deprecated, use `torch.distributed.checkpoint` instead
  from torch.distributed._shard.checkpoint import (
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  9.09it/s]
--> Model /root/autodl-tmp/model/llama-3-8b-instruct

--> /root/autodl-tmp/model/llama-3-8b-instruct has 8030.261248 Million params

trainable params: 54,525,952 || all params: 8,084,787,200 || trainable%: 0.6744
```




## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes?  
- [X] Did you write any new necessary tests?

Thanks for contributing 🎉!
