### PR TITLE
fix Colab link in quickstart_peft_finetuning.ipynb

### DIFF
--- a/recipes/quickstart/finetuning/quickstart_peft_finetuning.ipynb
+++ b/recipes/quickstart/finetuning/quickstart_peft_finetuning.ipynb
@@ -8,7 +8,7 @@
     "Copyright (c) Meta Platforms, Inc. and affiliates.\n",
     "This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/meta-llama/llama-recipes/blob/main/recipes/finetuning/quickstart_peft_finetuning.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/meta-llama/llama-recipes/blob/main/recipes/quickstart/finetuning/quickstart_peft_finetuning.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do?

## Feature/Issue validation/testing

Clicking on the "Open in Colab" link doesn't open the notebook in Colab because the location in the github repository has changed. This PR only fixes the link in this specific notebook, other notebooks may or may not have the same issue.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).