### PR TITLE
Fix fine-tuning training loss accumulation

### DIFF
--- a/src/llama_recipes/utils/train_utils.py
+++ b/src/llama_recipes/utils/train_utils.py
@@ -151,11 +151,11 @@ def train(model, train_dataloader,eval_dataloader, tokenizer, optimizer, lr_sche
                                 batch[key] = batch[key].to('cuda:0')
                     with autocast():
                         loss = model(**batch).loss
+                    total_loss += loss.detach().float()
                     loss = loss / gradient_accumulation_steps
                     if train_config.save_metrics:
                         train_step_loss.append(loss.detach().float().item())
                         train_step_perplexity.append(float(torch.exp(loss.detach().float())))
-                    total_loss += loss.detach().float()
                     if train_config.use_fp16:
                         # if fp16 is enabled, use gradient scaler to handle gradient update
                         scaler.scale(loss).backward()


### PR DESCRIPTION
# What does this PR do?

## Problem:
In /src/llama_recipes/utils/train_utils.py the training loss is correctly divided by the # of gradient accumulation steps to scale down the gradient:

loss = loss / gradient_accumulation_steps

The training loss is then accumulated

total_loss += loss.detach().float()

and used in the following to calculate the average loss across all samples in the epoch:

train_epoch_loss = total_loss / len(train_dataloader)

As the accumulated loss is scaled down by gradient_accumulation_steps and len(train_dataloader) includes all steps (even the gradient accumulation ones), train_epoch_loss is gradient_accumulation_steps times lower than it should be.

## Solution:

Accumulate the loss
total_loss += loss.detach().float()

before scaling it down

loss = loss / gradient_accumulation_steps

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ X ] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
