### PR TITLE
Fix quickstart notebookllama

### DIFF
--- a/recipes/quickstart/NotebookLlama/Step-4-TTS-Workflow.ipynb
+++ b/recipes/quickstart/NotebookLlama/Step-4-TTS-Workflow.ipynb
@@ -69,7 +69,10 @@
    "source": [
     "from IPython.display import Audio\n",
     "import IPython.display as ipd\n",
-    "from tqdm import tqdm"
+    "from tqdm import tqdm\n",
+    "import io\n",
+    "from scipy.io import wavfile\n",
+    "from pydub import AudioSegment"
    ]
   },
   {

--- a/recipes/quickstart/NotebookLlama/requirements.txt
+++ b/recipes/quickstart/NotebookLlama/requirements.txt
@@ -6,6 +6,9 @@ accelerate>=0.27.0
 rich>=13.0.0
 ipywidgets>=8.0.0
 tqdm>=4.66.0
+# pydub need mmpeg: apt install mmpeg
+pydub>=0.25.0
+git+https://github.com/huggingface/parler-tts.git
 
 # Optional but recommended
 jupyter>=1.0.0

--- a/recipes/quickstart/NotebookLlama/requirements.txt
+++ b/recipes/quickstart/NotebookLlama/requirements.txt
@@ -1,7 +1,7 @@
 # Core dependencies
 PyPDF2>=3.0.0
 torch>=2.0.0
-transformers>=4.46.0
+transformers>=4.43.0
 accelerate>=0.27.0
 rich>=13.0.0
 ipywidgets>=8.0.0
@@ -13,6 +13,3 @@ git+https://github.com/huggingface/parler-tts.git
 # Optional but recommended
 jupyter>=1.0.0
 ipykernel>=6.0.0
-
-# Warning handling
-warnings>=0.1.0


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Please include a good title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

-->

<!-- Remove if not applicable -->

Fix NotebookLlama demo

- remove pkg `warnings` from requirements, since we can directly `import warnings` in python 3
- add imports for `wavfile`, `AudioSegment` and `io` to 'Step-4-TTS-Workflow.ipynb'
- add dependencies for `pydub` and `parler-tts` required from 'Step-4-TTS-Workflow.ipynb'
- downgrade `transformers` version to 4.43.0, to be compatible with `parler-tts`'s dependency



## Feature/Issue validation/testing


not applicable

