### PR TITLE
Update wandb.py to accept setting run name from command line argument (e.g., --wandb_config.name "run_name") for fine tuning

### DIFF
--- a/src/llama_recipes/configs/wandb.py
+++ b/src/llama_recipes/configs/wandb.py
@@ -13,3 +13,4 @@ class wandb_config:
     group: Optional[str] = None
     notes: Optional[str] = None
     mode: Optional[str] = None
+    name: Optional[str] = None


### PR DESCRIPTION
# What does this PR do?

Current wandb logging generate a random run name (despite wandb supporting assigning a run name); I added a missing name attribute to wandb_config, so one could use command line argument like this `--wandb_config.name "run_name"` to control the displayed run_name on the wandb webpage.

## Feature/Issue validation/testing

Before and after the change of this commit, and use argument --wandb_config.name "fake run name". Note that `stoic-eon-2` is a random name. 

<img width="611" alt="Screenshot 2024-11-04 at 15 43 29" src="https://github.com/user-attachments/assets/a5149da4-8a9c-4202-8359-de07c4a3ae83">

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?  
- [x] Did you write any new necessary tests?