### PR TITLE
Fix import for XCCl availability check

### DIFF
--- a/src/llama_cookbook/utils/train_utils.py
+++ b/src/llama_cookbook/utils/train_utils.py
@@ -22,7 +22,7 @@ import json
 from llama_cookbook.model_checkpointing import save_fsdp_model_checkpoint_full, save_model_and_optimizer_sharded, save_optimizer_checkpoint, save_peft_checkpoint, save_model_checkpoint
 from llama_cookbook.policies import fpSixteen,bfSixteen, get_llama_wrapper
 from llama_cookbook.utils.memory_utils import MemoryTrace
-from accelerate.utils import is_xpu_available, is_ccl_available
+from accelerate.utils import is_xpu_available, is_xccl_available
 from llama_cookbook.utils.flop_utils import FlopMeasure
 def set_tokenizer_params(tokenizer: LlamaTokenizer):
     tokenizer.pad_token_id = 0
@@ -428,7 +428,7 @@ def check_frozen_layers_peft_model(model):
 
 def setup():
     """Initialize the process group for distributed training"""
-    if is_ccl_available():
+    if is_xccl_available():
         # distributed training on xpus
         dist.init_process_group("ccl")
     else:


### PR DESCRIPTION
# fix: correct ImportError in train_utils by updating accelerate.utils imports
This PR fixes a blocking ImportError in llama_cookbook/utils/train_utils.py that occurs when attempting to initialize training (specifically tested with QLoRA). The script tries to import is_ccl_available from accelerate.utils, but in current environments/versions of accelerate, this attribute is named is_xccl_available.

Motivation and Context:
While running fine-tuning on XPU-equipped clusters (like EuroHPC), the training process crashes immediately during the import phase. Correcting this import allows the `train_utils.py` to correctly identify the availability of the Collective Communications Library (CCL) for XPU backends.

Error Log:

````Python
File ".../llama_cookbook/utils/train_utils.py", line 26, in <module>
    from accelerate.utils import is_xpu_available, is_ccl_available
ImportError: cannot import name 'is_ccl_available' from 'accelerate.utils'
```

Feature/Issue validation/testing
I have verified the fix by running a QLoRA fine-tuning session.

[x] Test A: QLoRA Fine-tuning Initialization

Model: `meta-llama/CodeLlama-7b-Instruct-hf`

Environment: Python 3.11, requirements  installed.

Result: Before the fix, the script failed with ImportError. After changing the import to is_xccl_available, the training pipeline initializes correctly and the model starts training as expected.

Before submitting
[x] This PR fixes a typo or improves the docs.

[] Did you read the [contributor guideline](https://github.com/meta-llama/llama-cookbook/blob/main/CONTRIBUTING.md), Pull Request section?

[ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.

[ ] Did you make sure to update the documentation with your changes?

[ ] Did you write any new necessary tests?