### PR TITLE
fix: WhatsApp bot undefined var, hardcoded URL, wrong package

### DIFF
--- a/end-to-end-use-cases/whatsapp_llama_4_bot/requirements.txt
+++ b/end-to-end-use-cases/whatsapp_llama_4_bot/requirements.txt
@@ -10,7 +10,6 @@ charset-normalizer==3.4.1
 click==8.1.8
 colorama==0.4.6
 distro==1.9.0
-dotenv==0.9.9
 eval_type_backport==0.2.2
 exceptiongroup==1.2.2
 fastapi==0.115.12

--- a/end-to-end-use-cases/whatsapp_llama_4_bot/webhook_utils.py
+++ b/end-to-end-use-cases/whatsapp_llama_4_bot/webhook_utils.py
@@ -52,11 +52,11 @@ async def send_message_async(user_phone: str, message: str):
 async def send_audio_message(to: str, file_path: str):
     url = f"https://graph.facebook.com/v20.0/{PHONE_NUMBER_ID}/media"
     with open(file_path, "rb") as f:
-        files = { "file": ("reply.mp3", open(file_path, "rb"), "audio/mpeg")}
+        files = { "file": ("reply.mp3", f, "audio/mpeg")}
         params = {
             "messaging_product": "whatsapp",
             "type": "audio",
-            "access_token": ACCESS_TOKEN
+            "access_token": META_ACCESS_TOKEN
         }
         response = requests.post(url, params=params, files=files)
 
@@ -69,7 +69,7 @@ async def send_audio_message(to: str, file_path: str):
             "audio": {"id": media_id}
         }
         headers = {
-            "Authorization": f"Bearer {ACCESS_TOKEN}",
+            "Authorization": f"Bearer {META_ACCESS_TOKEN}",
             "Content-Type": "application/json"
         }
         requests.post(WHATSAPP_API_URL, headers=headers, json=payload)
@@ -96,7 +96,7 @@ async def llm_reply_to_text_v2(user_input: str, user_phone: str, media_id: str =
         }
         
         async with httpx.AsyncClient() as client:
-          response = await client.post("https://df00-171-60-176-142.ngrok-free.app/llm-response", json=json_data, headers=headers,timeout=60)
+          response = await client.post(f"{BASE_URL}/llm-response", json=json_data, headers=headers,timeout=60)
           response_data = response.json()
           # print(response_data)
           if response.status_code == 200 and response_data['error'] == None:


### PR DESCRIPTION
## Summary
- Replace undefined `ACCESS_TOKEN` with `META_ACCESS_TOKEN` (runtime crash on line 59/72)
- Replace hardcoded ngrok tunnel URL with `BASE_URL` env var
- Fix file handle leak in `send_audio_message` (file opened twice)
- Remove wrong `dotenv==0.9.9` package (correct `python-dotenv` already listed)

## Motivation
`send_audio_message()` crashes at runtime because `ACCESS_TOKEN` is never defined — only `META_ACCESS_TOKEN` is. A developer's ngrok URL was committed. The `dotenv` PyPI package is not `python-dotenv`.

## Test plan
- [ ] Verify `webhook_utils.py` has no references to undefined variables
- [ ] Verify no hardcoded URLs remain
- [ ] Verify requirements.txt installs cleanly