### PR TITLE
fix: update root dependencies and Python version floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "Llama-cookbook is a companion project to the Llama models. It's goal is to provide examples to quickly get started with fine-tuning for domain adaptation and how to run inference for the fine-tuned models."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: Other/Proprietary License",

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,10 @@ typing-extensions>=4.8.0
 tabulate
 evaluate
 rouge_score
-pyyaml==6.0.1
-faiss-gpu; python_version < '3.11'
+pyyaml>=6.0.1
+faiss-cpu
 unstructured[pdf]
 sentence_transformers
 codeshield
 gradio
-markupsafe==2.0.1
+markupsafe>=2.1


### PR DESCRIPTION
## Summary
- `markupsafe==2.0.1` -> `>=2.1` (5-year-old pin, conflicts with modern Jinja2)
- `pyyaml==6.0.1` -> `>=6.0.1` (remove exact pin blocking security patches)
- `faiss-gpu` -> `faiss-cpu` (faiss-gpu on PyPI is unmaintained)
- `requires-python >=3.8` -> `>=3.10` (Python 3.8 EOL Oct 2024)

## Motivation
The exact `markupsafe` pin dates to 2021 and conflicts with many modern libraries. `faiss-gpu` on PyPI is no longer maintained for newer CUDA versions. Python 3.8 is end-of-life and the codebase already requires 3.10+ features.

## Test plan
- [ ] `pip install -e '.[tests]'` succeeds on Python 3.10+
- [ ] `pytest src/tests/` passes