### PR TITLE
fix: use stable CPU PyTorch wheels in CI, update checkout action

### DIFF
--- a/.github/workflows/pytest_cpu_gha_runner.yaml
+++ b/.github/workflows/pytest_cpu_gha_runner.yaml
@@ -18,7 +18,7 @@ on:
           default: "true"
 
 env:
-  PYTORCH_WHEEL_URL: https://download.pytorch.org/whl/test/cu118
+  PYTORCH_WHEEL_URL: https://download.pytorch.org/whl/cpu
 
 jobs:
   execute_workflow:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Lint changed files
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
 
@@ -33,7 +33,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Switch PyTorch wheel URL from `test/cu118` (nightly, CUDA) to `cpu` (stable, CPU-only)
- Update `actions/checkout@v3` to `@v4` in spellcheck workflow

## Motivation
The pytest CI runs on a CPU-only `ubuntu-24.04` runner but was pulling CUDA 11.8 test/nightly wheels — wasteful and potentially unstable.

## Test plan
- [ ] CI pytest workflow installs and runs successfully
- [ ] Spellcheck workflow runs successfully