### PR TITLE
chore: update license headers from Llama 2/3 to Llama

### DIFF
--- a/.github/scripts/check_copyright_header.py
+++ b/.github/scripts/check_copyright_header.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import re
 from pathlib import Path
@@ -8,7 +8,7 @@ WORK_DIR = Path(__file__).parents[1]
 PATTERN = "(Meta Platforms, Inc. and affiliates)|(Facebook, Inc(\.|,)? and its affiliates)|([0-9]{4}-present(\.|,)? Facebook)|([0-9]{4}(\.|,)? Facebook)"
 
 HEADER = """# Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.\n\n"""
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.\n\n"""
 
 #Files in black list must be relative to main repo folder
 BLACKLIST = ["tools/benchmarks/llm_eval_harness/open_llm_leaderboard/hellaswag_utils.py"]

--- a/.github/scripts/spellcheck.sh
+++ b/.github/scripts/spellcheck.sh
@@ -1,6 +1,6 @@
 
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 # Source: https://github.com/pytorch/torchx/blob/main/scripts/spellcheck.sh
 set -ex
 sudo apt-get install aspell

--- a/3p-integrations/tgi/merge_lora_weights.py
+++ b/3p-integrations/tgi/merge_lora_weights.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import fire
 import torch

--- a/3p-integrations/vllm/inference.py
+++ b/3p-integrations/vllm/inference.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import uuid
 import asyncio

--- a/end-to-end-use-cases/RAFT-Chatbot/config.py
+++ b/end-to-end-use-cases/RAFT-Chatbot/config.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import yaml
 

--- a/end-to-end-use-cases/RAFT-Chatbot/raft_eval.py
+++ b/end-to-end-use-cases/RAFT-Chatbot/raft_eval.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 import logging
 import evaluate
 import argparse

--- a/end-to-end-use-cases/RAFT-Chatbot/raft_utils.py
+++ b/end-to-end-use-cases/RAFT-Chatbot/raft_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import os
 import logging

--- a/end-to-end-use-cases/benchmarks/inference/cloud/azure/chat_azure_api_benchmark.py
+++ b/end-to-end-use-cases/benchmarks/inference/cloud/azure/chat_azure_api_benchmark.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import csv
 import json

--- a/end-to-end-use-cases/benchmarks/inference/cloud/azure/pretrained_azure_api_benchmark.py
+++ b/end-to-end-use-cases/benchmarks/inference/cloud/azure/pretrained_azure_api_benchmark.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import csv
 import json

--- a/end-to-end-use-cases/benchmarks/inference/on_prem/vllm/chat_vllm_benchmark.py
+++ b/end-to-end-use-cases/benchmarks/inference/on_prem/vllm/chat_vllm_benchmark.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import csv
 import json

--- a/end-to-end-use-cases/benchmarks/inference/on_prem/vllm/pretrained_vllm_benchmark.py
+++ b/end-to-end-use-cases/benchmarks/inference/on_prem/vllm/pretrained_vllm_benchmark.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import csv
 import json

--- a/end-to-end-use-cases/benchmarks/llm_eval_harness/meta_eval/prepare_meta_eval.py
+++ b/end-to-end-use-cases/benchmarks/llm_eval_harness/meta_eval/prepare_meta_eval.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import argparse
 import errno

--- a/end-to-end-use-cases/coding/text2sql/csv2db.py
+++ b/end-to-end-use-cases/coding/text2sql/csv2db.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import sqlite3
 import csv

--- a/end-to-end-use-cases/coding/text2sql/txt2csv.py
+++ b/end-to-end-use-cases/coding/text2sql/txt2csv.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import csv
 

--- a/getting-started/finetuning/datasets/custom_dataset.py
+++ b/getting-started/finetuning/datasets/custom_dataset.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 # For dataset details visit: https://huggingface.co/datasets/samsum
 

--- a/getting-started/finetuning/datasets/ocrvqa_dataset.py
+++ b/getting-started/finetuning/datasets/ocrvqa_dataset.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 
 import copy

--- a/getting-started/finetuning/datasets/raft_dataset.py
+++ b/getting-started/finetuning/datasets/raft_dataset.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 
 import copy

--- a/getting-started/finetuning/finetuning.py
+++ b/getting-started/finetuning/finetuning.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import fire
 from llama_cookbook.finetuning import main

--- a/getting-started/finetuning/quickstart_peft_finetuning.ipynb
+++ b/getting-started/finetuning/quickstart_peft_finetuning.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "Copyright (c) Meta Platforms, Inc. and affiliates.\n",
-    "This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.\n",
+    "This software may be used and distributed according to the terms of the Llama Community License Agreement.\n",
     "\n",
     "<a href=\"https://colab.research.google.com/github/meta-llama/llama-cookbook/blob/main/getting-started/finetuning/quickstart_peft_finetuning.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]

--- a/getting-started/inference/local_inference/chat_completion/chat_completion.py
+++ b/getting-started/inference/local_inference/chat_completion/chat_completion.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 # from accelerate import init_empty_weights, load_checkpoint_and_dispatch
 

--- a/getting-started/inference/local_inference/inference.py
+++ b/getting-started/inference/local_inference/inference.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 3 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import os
 import sys

--- a/src/llama_cookbook/configs/__init__.py
+++ b/src/llama_cookbook/configs/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from llama_cookbook.configs.peft import lora_config, llama_adapter_config, prefix_config
 from llama_cookbook.configs.fsdp import fsdp_config

--- a/src/llama_cookbook/configs/datasets.py
+++ b/src/llama_cookbook/configs/datasets.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from dataclasses import dataclass
 

--- a/src/llama_cookbook/configs/fsdp.py
+++ b/src/llama_cookbook/configs/fsdp.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from dataclasses import dataclass
 

--- a/src/llama_cookbook/configs/peft.py
+++ b/src/llama_cookbook/configs/peft.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from dataclasses import dataclass, field
 from typing import List

--- a/src/llama_cookbook/configs/quantization.py
+++ b/src/llama_cookbook/configs/quantization.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from dataclasses import dataclass
 from typing import Optional

--- a/src/llama_cookbook/configs/training.py
+++ b/src/llama_cookbook/configs/training.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from dataclasses import dataclass
 

--- a/src/llama_cookbook/configs/wandb.py
+++ b/src/llama_cookbook/configs/wandb.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from typing import List, Optional
 from dataclasses import dataclass, field

--- a/src/llama_cookbook/data/__init__.py
+++ b/src/llama_cookbook/data/__init__.py
@@ -1,2 +1,2 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.

--- a/src/llama_cookbook/data/concatenator.py
+++ b/src/llama_cookbook/data/concatenator.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from tqdm import tqdm
 from itertools import chain

--- a/src/llama_cookbook/data/llama_guard/finetuning_data_formatter_example.py
+++ b/src/llama_cookbook/data/llama_guard/finetuning_data_formatter_example.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from finetuning_data_formatter import TrainingExample, Guidelines, Category, LlamaGuardPromptConfigs, LlamaGuardGenerationConfigs, ExplanationPosition, AugmentationConfigs, FormatterConfigs, create_formatted_finetuning_examples
 

--- a/src/llama_cookbook/data/sampler.py
+++ b/src/llama_cookbook/data/sampler.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import random
 from itertools import islice

--- a/src/llama_cookbook/datasets/__init__.py
+++ b/src/llama_cookbook/datasets/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from functools import partial
 

--- a/src/llama_cookbook/datasets/alpaca_dataset.py
+++ b/src/llama_cookbook/datasets/alpaca_dataset.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 # For dataset details visit: https://crfm.stanford.edu/2023/03/13/alpaca.html
 

--- a/src/llama_cookbook/datasets/grammar_dataset/__init__.py
+++ b/src/llama_cookbook/datasets/grammar_dataset/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 

--- a/src/llama_cookbook/datasets/grammar_dataset/grammar_dataset.py
+++ b/src/llama_cookbook/datasets/grammar_dataset/grammar_dataset.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 # For dataset details visit: https://huggingface.co/datasets/jfleg
 # For download and preparation see: recipes/ft_datasets/grammar_dataset/grammar_dataset_process.ipynb

--- a/src/llama_cookbook/datasets/grammar_dataset/grammar_dataset_process.ipynb
+++ b/src/llama_cookbook/datasets/grammar_dataset/grammar_dataset_process.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "Copyright (c) Meta Platforms, Inc. and affiliates.\n",
-    "This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.\n",
+    "This software may be used and distributed according to the terms of the Llama Community License Agreement.\n",
     "\n",
     "Use this notebook to pull in datasets and apply pre-processing.  Most grammar datasets unfortunately require preprocessing before being usable in training. (example - jfleg has 4 targets per input, so we have to rematch as 1:1 pairings) "
    ]

--- a/src/llama_cookbook/datasets/samsum_dataset.py
+++ b/src/llama_cookbook/datasets/samsum_dataset.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 # For dataset details visit: https://huggingface.co/datasets/samsum
 

--- a/src/llama_cookbook/finetuning.py
+++ b/src/llama_cookbook/finetuning.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import dataclasses
 import os

--- a/src/llama_cookbook/inference/__init__.py
+++ b/src/llama_cookbook/inference/__init__.py
@@ -1,2 +1,2 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.

--- a/src/llama_cookbook/inference/chat_utils.py
+++ b/src/llama_cookbook/inference/chat_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import json
 

--- a/src/llama_cookbook/inference/checkpoint_converter_fsdp_hf.py
+++ b/src/llama_cookbook/inference/checkpoint_converter_fsdp_hf.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 # from accelerate import init_empty_weights, load_checkpoint_and_dispatch
 

--- a/src/llama_cookbook/inference/prompt_format_utils.py
+++ b/src/llama_cookbook/inference/prompt_format_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from dataclasses import dataclass
 from string import Template

--- a/src/llama_cookbook/inference/safety_utils.py
+++ b/src/llama_cookbook/inference/safety_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import os
 import torch

--- a/src/llama_cookbook/model_checkpointing/__init__.py
+++ b/src/llama_cookbook/model_checkpointing/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from llama_cookbook.model_checkpointing.checkpoint_handler import (
     load_model_checkpoint,

--- a/src/llama_cookbook/model_checkpointing/checkpoint_handler.py
+++ b/src/llama_cookbook/model_checkpointing/checkpoint_handler.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from pathlib import Path
 from datetime import datetime

--- a/src/llama_cookbook/policies/__init__.py
+++ b/src/llama_cookbook/policies/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from llama_cookbook.policies.mixed_precision import *
 from llama_cookbook.policies.wrapping import *

--- a/src/llama_cookbook/policies/activation_checkpointing_functions.py
+++ b/src/llama_cookbook/policies/activation_checkpointing_functions.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from functools import partial
 

--- a/src/llama_cookbook/policies/anyprecision_optimizer.py
+++ b/src/llama_cookbook/policies/anyprecision_optimizer.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 # AnyPrecisionAdamW: a flexible precision AdamW optimizer
 # with optional Kahan summation for high precision weight updates.

--- a/src/llama_cookbook/policies/mixed_precision.py
+++ b/src/llama_cookbook/policies/mixed_precision.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import torch
 

--- a/src/llama_cookbook/policies/wrapping.py
+++ b/src/llama_cookbook/policies/wrapping.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import functools
 

--- a/src/llama_cookbook/tools/compare_llama_weights.py
+++ b/src/llama_cookbook/tools/compare_llama_weights.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import gc
 import glob

--- a/src/llama_cookbook/tools/convert_hf_weights_to_llama.py
+++ b/src/llama_cookbook/tools/convert_hf_weights_to_llama.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import json
 import os

--- a/src/llama_cookbook/utils/__init__.py
+++ b/src/llama_cookbook/utils/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from llama_cookbook.utils.memory_utils import MemoryTrace
 from llama_cookbook.utils.dataset_utils import *

--- a/src/llama_cookbook/utils/config_utils.py
+++ b/src/llama_cookbook/utils/config_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import inspect
 from dataclasses import asdict

--- a/src/llama_cookbook/utils/dataset_utils.py
+++ b/src/llama_cookbook/utils/dataset_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import torch
 

--- a/src/llama_cookbook/utils/fsdp_utils.py
+++ b/src/llama_cookbook/utils/fsdp_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 import os 
 import torch
 import torch.cuda.nccl as nccl

--- a/src/llama_cookbook/utils/memory_utils.py
+++ b/src/llama_cookbook/utils/memory_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import gc
 import psutil

--- a/src/llama_cookbook/utils/plot_metrics.py
+++ b/src/llama_cookbook/utils/plot_metrics.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import json
 import matplotlib.pyplot as plt

--- a/src/llama_cookbook/utils/train_utils.py
+++ b/src/llama_cookbook/utils/train_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import os
 import time
@@ -22,7 +22,12 @@ import json
 from llama_cookbook.model_checkpointing import save_fsdp_model_checkpoint_full, save_model_and_optimizer_sharded, save_optimizer_checkpoint, save_peft_checkpoint, save_model_checkpoint
 from llama_cookbook.policies import fpSixteen,bfSixteen, get_llama_wrapper
 from llama_cookbook.utils.memory_utils import MemoryTrace
-from accelerate.utils import is_xpu_available, is_ccl_available
+from accelerate.utils import is_xpu_available
+try:
+    from accelerate.utils import is_ccl_available
+except ImportError:
+    def is_ccl_available():
+        return False
 from llama_cookbook.utils.flop_utils import FlopMeasure
 def set_tokenizer_params(tokenizer: LlamaTokenizer):
     tokenizer.pad_token_id = 0

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import pytest
 

--- a/src/tests/datasets/test_custom_dataset.py
+++ b/src/tests/datasets/test_custom_dataset.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import pytest
 from contextlib import nullcontext

--- a/src/tests/datasets/test_grammar_datasets.py
+++ b/src/tests/datasets/test_grammar_datasets.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from pathlib import Path
 import pytest

--- a/src/tests/datasets/test_samsum_datasets.py
+++ b/src/tests/datasets/test_samsum_datasets.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from dataclasses import dataclass
 from functools import partial

--- a/src/tests/test_batching.py
+++ b/src/tests/test_batching.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import pytest
 from contextlib import nullcontext

--- a/src/tests/test_finetuning.py
+++ b/src/tests/test_finetuning.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import os
 from contextlib import nullcontext

--- a/src/tests/test_sampler.py
+++ b/src/tests/test_sampler.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 import random
 import pytest

--- a/src/tests/test_train_utils.py
+++ b/src/tests/test_train_utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from unittest.mock import patch
 import pytest

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
+# This software may be used and distributed according to the terms of the Llama Community License Agreement.
 
 from transformers import AutoTokenizer
 


### PR DESCRIPTION
## Summary
Update copyright headers across 69 files from version-specific license references to a generic form:

`Llama 2 Community License Agreement` / `Llama 3 Community License Agreement`
-> `Llama Community License Agreement`

Also updates `check_copyright_header.py` to enforce the new format.

## Motivation
The code supports Llama 2 through Llama 4. Version-specific license headers are inaccurate.

## Test plan
- [ ] `grep -r "Llama [23] Community License" --include="*.py" .` returns no results (excluding PLAN.md)
- [ ] `check_copyright_header.py` uses the updated header text