### PR TITLE
chore: add Makefile and fix stale README refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: install install-dev test lint format clean
+
+install:
+	pip install -e .
+
+install-dev:
+	pip install -e '.[tests]'
+
+test:
+	python -m pytest src/tests/ -v
+
+lint:
+	python -m py_compile src/llama_cookbook/finetuning.py
+	@echo "Lint passed"
+
+format:
+	black src/
+
+clean:
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .ipynb_checkpoints -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete 2>/dev/null || true

--- a/end-to-end-use-cases/NotebookLlama/README.md
+++ b/end-to-end-use-cases/NotebookLlama/README.md
@@ -41,8 +41,8 @@ You'll need your Hugging Face access token, which you can get at your Settings p
 - First, please Install the requirements from [here]() by running inside the folder:
 
 ```
-git clone https://github.com/meta-llama/llama-recipes
-cd llama-recipes/end-to-end-use-cases/NotebookLlama/
+git clone https://github.com/meta-llama/llama-cookbook
+cd llama-cookbook/end-to-end-use-cases/NotebookLlama/
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
## Summary
- Add `Makefile` with `install`, `install-dev`, `test`, `lint`, `format`, `clean` targets
- Fix stale `llama-recipes` clone URL in `NotebookLlama/README.md`

## Test plan
- [ ] `make install-dev` installs the project
- [ ] `make test` runs the test suite
- [ ] NotebookLlama README clone URL is correct