### PR TITLE
Add MiniMax hosted LLM provider

### DIFF
--- a/src/llama_cookbook/inference/llm.py
+++ b/src/llama_cookbook/inference/llm.py
@@ -157,3 +157,31 @@ class ANYSCALE(LLM):
             "mistralai/Mistral-7B-Instruct-v0.1",
             "HuggingFaceH4/zephyr-7b-beta",
         ]
+
+
+class MINIMAX(LLM):
+    """Accessing MiniMax"""
+
+    def __init__(self, model: str, api_key: str) -> None:
+        super().__init__(model, api_key)
+        self.client = openai.OpenAI(base_url="https://api.minimax.io/v1", api_key=api_key)  # noqa
+
+    @override
+    def query(self, prompt: str) -> str:
+        # Best-level effort to suppress openai log-spew.
+        # Likely not work well in multi-threaded environment.
+        level = logging.getLogger().level
+        logging.getLogger().setLevel(logging.WARNING)
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "user", "content": prompt},
+            ],
+            max_tokens=MAX_TOKENS,
+        )
+        logging.getLogger().setLevel(level)
+        return response.choices[0].message.content
+
+    @override
+    def valid_models(self) -> list[str]:
+        return ["MiniMax-M3"]


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add a MiniMax provider wrapper alongside the existing OpenAI-compatible hosted LLM providers.
- Register MiniMax-M3 as the supported MiniMax model and use MiniMax's OpenAI-compatible API base URL.

## Test plan
- python3 -m py_compile /root/octopatch-4/work/repos/meta-llama_llama-cookbook/src/llama_cookbook/inference/llm.py